### PR TITLE
fix: hash hostname in fingerprint, portable validation paths, remove dead code

### DIFF
--- a/src/gep/assetStore.js
+++ b/src/gep/assetStore.js
@@ -26,14 +26,11 @@ function writeJsonAtomic(filePath, obj) {
   fs.renameSync(tmp, filePath);
 }
 
-// Build a robust validation command that works regardless of CWD.
-// Resolves module paths relative to the skill root (skills/evolver/).
+// Build a validation command using repo-root-relative paths.
+// runValidations() executes with cwd=repoRoot, so require('./src/...')
+// resolves correctly without embedding machine-specific absolute paths.
 function buildValidationCmd(relModules) {
-  const skillRoot = path.resolve(__dirname, '..', '..');
-  const checks = relModules.map(m => {
-    const abs = path.join(skillRoot, m).replace(/\\/g, '/');
-    return `require('${abs}')`;
-  });
+  const checks = relModules.map(m => `require('./${m}')`);
   return `node -e "${checks.join('; ')}; console.log('ok')"`;
 }
 
@@ -216,14 +213,6 @@ function upsertGene(geneObj) {
   writeJsonAtomic(genesPath(), { version: current.version || 1, genes });
 }
 
-function appendCapsule(capsuleObj) {
-  ensureSchemaFields(capsuleObj);
-  const current = readJsonIfExists(capsulesPath(), getDefaultCapsules());
-  const capsules = Array.isArray(current.capsules) ? current.capsules : [];
-  capsules.push(capsuleObj);
-  writeJsonAtomic(capsulesPath(), { version: current.version || 1, capsules });
-}
-
 function upsertCapsule(capsuleObj) {
   if (!capsuleObj || capsuleObj.type !== 'Capsule' || !capsuleObj.id) return;
   ensureSchemaFields(capsuleObj);
@@ -263,7 +252,7 @@ module.exports = {
   loadGenes, loadCapsules, readAllEvents, getLastEventId,
   appendEventJsonl, appendCandidateJsonl, appendExternalCandidateJsonl,
   readRecentCandidates, readRecentExternalCandidates,
-  upsertGene, appendCapsule, upsertCapsule,
+  upsertGene, upsertCapsule,
   genesPath, capsulesPath, eventsPath, candidatesPath, externalCandidatesPath,
   ensureAssetFiles, buildValidationCmd,
 };

--- a/src/gep/envFingerprint.js
+++ b/src/gep/envFingerprint.js
@@ -26,7 +26,7 @@ function captureEnvFingerprint() {
     platform: process.platform,
     arch: process.arch,
     os_release: os.release(),
-    hostname: os.hostname(),
+    hostname: crypto.createHash('sha256').update(os.hostname()).digest('hex').slice(0, 12),
     evolver_version: pkgVersion,
     cwd: process.cwd(),
     container: isContainer(),

--- a/src/gep/solidify.js
+++ b/src/gep/solidify.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const { execSync } = require('child_process');
-const { loadGenes, upsertGene, appendEventJsonl, appendCapsule, upsertCapsule, getLastEventId } = require('./assetStore');
+const { loadGenes, upsertGene, appendEventJsonl, upsertCapsule, getLastEventId } = require('./assetStore');
 const { computeSignalKey, memoryGraphPath } = require('./memoryGraph');
 const { computeCapsuleSuccessStreak, isBlastRadiusSafe } = require('./a2a');
 const { getRepoRoot, getMemoryDir, getEvolutionDir, getWorkspaceRoot } = require('./paths');


### PR DESCRIPTION
## Summary

Three fixes targeting privacy, portability, and dead code:

### 1. Hash hostname before storing in env fingerprint (`envFingerprint.js`)

`os.hostname()` was stored verbatim in every Capsule and EvolutionEvent that gets published to the public Hub. `sanitize.js` does not cover hostnames (its redact patterns target tokens, `/Users/` paths, and emails — not arbitrary hostnames), so strings like `john-macbook-pro.local` leaked into the public feed.

**Fix:** Replace the raw hostname with a 12-character SHA-256 prefix. The value still uniquely identifies an environment class for GDI measurement, without leaking machine identity.

```js
// before
hostname: os.hostname()

// after
hostname: crypto.createHash('sha256').update(os.hostname()).digest('hex').slice(0, 12)
```

`envFingerprintKey` and `isSameEnvClass` continue to work correctly — verified.

---

### 2. Remove absolute paths from `buildValidationCmd` (`assetStore.js`)

The previous implementation called `path.resolve(__dirname, '..', '..')` to build absolute paths like `/Users/xxx/codespace/evolver/src/evolve`, which were embedded into Gene `validation` commands stored in `genes.json`.

Two problems:
- `sanitize.js` redacts `/Users/...` in published Capsules, **corrupting** the stored validation command for anyone who downloads a Gene bundle from the Hub.
- Moving the project directory breaks **all previously stored Gene validation commands**.

`runValidations()` already executes with `cwd: repoRoot` (see `solidify.js:567`), so `require('./src/evolve')` style relative paths resolve correctly.

```js
// before — embeds /Users/xxx/... absolute path
node -e "require('/Users/xxx/codespace/evolver/src/evolve'); ..."

// after — portable, works wherever the repo root is
node -e "require('./src/evolve'); ..."
```

Tested: the generated commands run successfully from the repo root.

---

### 3. Remove `appendCapsule` dead code (`assetStore.js`, `solidify.js`)

`appendCapsule` was exported from `assetStore.js` and imported by `solidify.js` but **never called** — `solidify` exclusively uses `upsertCapsule`. The function also lacked deduplication logic, so any accidental call would grow `capsules.json` unboundedly with duplicate entries.

Removed the function, its export, and the unused import in `solidify.js`.

## Test plan

- [ ] Run an evolution cycle and confirm published Capsule `env_fingerprint.hostname` is a 12-char hex string, not the raw machine name
- [ ] Confirm `isSameEnvClass` returns `true` for two fingerprints taken on the same machine
- [ ] Inspect `genes.json` default genes — `validation` commands should use `require('./src/...')` relative paths
- [ ] Run the generated validation command from repo root: `node -e "require('./src/evolve'); require('./src/gep/solidify'); console.log('ok')"` — should print `ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to fingerprint serialization and command string generation plus dead-code removal; minimal behavioral impact beyond privacy and portability.
> 
> **Overview**
> Improves privacy and portability of published GEP assets by **hashing `env_fingerprint.hostname`** (12-char SHA-256 prefix) and generating Gene `validation` commands as repo-root-relative `require('./src/...')` paths instead of embedding absolute machine paths.
> 
> Removes dead capsule-writing API by deleting `appendCapsule` from `assetStore.js` and dropping its unused import from `solidify.js`, standardizing capsule persistence on `upsertCapsule`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 85f2b46d1ef98f4368a3a171867696ac83446186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->