### PR TITLE
fix: skip performMaintenance() in dry-run mode

### DIFF
--- a/src/evolve.js
+++ b/src/evolve.js
@@ -669,7 +669,12 @@ async function run() {
   }
 
   // Maintenance: Clean up old logs to keep directory scan fast
-  performMaintenance();
+  // Skip maintenance in dry-run mode to avoid side effects (file moves/deletes).
+  if (!IS_DRY_RUN) {
+    performMaintenance();
+  } else {
+    console.log('[Maintenance] Skipped (dry-run mode).');
+  }
 
   // --- Repair Loop Circuit Breaker ---
   // Detect when the evolver is stuck in a "repair -> fail -> repair" cycle.


### PR DESCRIPTION
## Problem

`performMaintenance()` runs unconditionally during `node index.js run --dry-run`, causing:
- 1000+ session logs moved to archive directory
- Evolver hand sessions deleted

Users expect `--dry-run` to be **read-only** with zero file system side effects.

## Fix

Guard the `performMaintenance()` call with `IS_DRY_RUN` check. When `--dry-run` is active, maintenance is skipped and a log message is printed instead.

## Testing

Before fix:
```
node index.js run --dry-run
[Maintenance] Found 1113 session logs. Archiving old ones...
[Maintenance] Archived 1063 logs to .../archive
```

After fix:
```
node index.js run --dry-run
[Maintenance] Skipped (dry-run mode).
```

Minimal change: 1 file, 6 insertions, 1 deletion.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized control-flow change that only affects `--dry-run` behavior and reduces filesystem side effects.
> 
> **Overview**
> `--dry-run` evolver runs are now read-only with respect to session log maintenance.
> 
> `src/evolve.js` guards the `performMaintenance()` call behind `!IS_DRY_RUN` and prints a skip message when dry-run is enabled, avoiding file deletes/moves (including archiving and `evolver_hand_` cleanup).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51a542569536fe16f6673ecfca5aee4cfb6db861. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->