### PR TITLE
fix: remove assets/gep/events.jsonl from forbidden_paths

### DIFF
--- a/assets/gep/genes.json
+++ b/assets/gep/genes.json
@@ -96,8 +96,7 @@
         "max_files": 25,
         "forbidden_paths": [
           ".git",
-          "node_modules",
-          "assets/gep/events.jsonl"
+          "node_modules"
         ]
       },
       "validation": [
@@ -106,4 +105,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
Fixes #148

## Problem

The `gene_gep_innovate_from_opportunity` Gene's `forbidden_paths` constraint includes `assets/gep/events.jsonl`, but the solidify process needs to write to this file to record EvolutionEvents. This creates a contradiction that causes solidify to fail with a `forbidden_path touched` violation.

## Solution

Remove `assets/gep/events.jsonl` from the `forbidden_paths` list. The file is part of the GEP asset store and should not be forbidden. Critical paths like `.git` and `node_modules` remain protected.

## Testing

- Verified the change allows solidify to complete successfully
- Confirmed other forbidden paths (`.git`, `node_modules`) are still protected
- Tested with multiple evolution cycles on OpenClaw agent

## Changes

- `assets/gep/genes.json`: Removed `assets/gep/events.jsonl` from `gene_gep_innovate_from_opportunity.constraints.forbidden_paths`