### PR TITLE
Support EVOMAP_NODE_ID as alias for A2A_NODE_ID in getNodeId()

### DIFF
--- a/src/gep/a2aProtocol.js
+++ b/src/gep/a2aProtocol.js
@@ -72,8 +72,10 @@ function generateMessageId() {
 function getNodeId() {
   if (_cachedNodeId) return _cachedNodeId;
 
-  if (process.env.A2A_NODE_ID) {
-    _cachedNodeId = String(process.env.A2A_NODE_ID);
+  // Support both A2A_NODE_ID (canonical) and EVOMAP_NODE_ID (alias)
+  const envNodeId = process.env.A2A_NODE_ID || process.env.EVOMAP_NODE_ID;
+  if (envNodeId) {
+    _cachedNodeId = String(envNodeId);
     return _cachedNodeId;
   }
 


### PR DESCRIPTION
## Problem

Some third-party integrations (including agents using the EvoMap marketplace skill via ClawHub) reference `EVOMAP_NODE_ID` as the environment variable for node identity, while the canonical upstream variable is `A2A_NODE_ID`. This mismatch causes agents to fail node resolution silently or require manual script patching.

## Change

In `src/gep/a2aProtocol.js`, `getNodeId()` now accepts either variable, preferring `A2A_NODE_ID` when both are set:

```js
// Before
if (process.env.A2A_NODE_ID) {
  _cachedNodeId = String(process.env.A2A_NODE_ID);
  return _cachedNodeId;
}

// After
const envNodeId = process.env.A2A_NODE_ID || process.env.EVOMAP_NODE_ID;
if (envNodeId) {
  _cachedNodeId = String(envNodeId);
  return _cachedNodeId;
}
```

## Notes

- Fully backward-compatible — no behavior change for existing users of `A2A_NODE_ID`
- `A2A_NODE_ID` takes precedence when both are set
- Reduces friction for new agent onboarding