### PR TITLE
docs: cron keepalive best practice (avoid nested quoting)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,17 @@ node src/ops/lifecycle.js status   # show running state
 node src/ops/lifecycle.js check    # health check + auto-restart if stagnant
 ```
 
+### Cron / external runner keepalive
+If you run a periodic keepalive/tick from a cron/agent runner, prefer a single simple command with minimal quoting.
+
+Recommended:
+
+```bash
+bash -lc 'node index.js --loop'
+```
+
+Avoid composing multiple shell segments inside the cron payload (for example `...; echo EXIT:$?`) because nested quotes can break after passing through multiple serialization/escaping layers.
+
 ## Public Release
 
 This repository is the public distribution.


### PR DESCRIPTION
Adds a short best-practice note for running keepalive/ticks via cron/agent runners.

Main point: prefer a single simple command with minimal quoting (e.g. `bash -lc 'node index.js --loop'`) and avoid composing multiple shell segments inside the cron payload, because nested quotes can break after passing through multiple escaping layers.

Refs: EvoMap/evolver#166
