### PR TITLE
feat: support flexible git repository detection for nested installations

### DIFF
--- a/src/gep/paths.js
+++ b/src/gep/paths.js
@@ -1,13 +1,42 @@
 const path = require('path');
+const fs = require('fs');
 
 function getRepoRoot() {
-  // src/gep/paths.js -> repo root
+  // Prioritize environment variable for flexible deployment
+  if (process.env.EVOLVER_REPO_ROOT) {
+    return process.env.EVOLVER_REPO_ROOT;
+  }
+  
+  // Auto-detect git repository root by walking up directory tree
+  // This allows evolver to work in a parent git repository
+  let dir = path.resolve(__dirname, '..', '..');
+  while (dir !== '/' && dir !== '.') {
+    const gitDir = path.join(dir, '.git');
+    if (fs.existsSync(gitDir)) {
+      return dir;
+    }
+    dir = path.dirname(dir);
+  }
+  
+  // Fallback to default (evolver's own directory)
   return path.resolve(__dirname, '..', '..');
 }
 
 function getWorkspaceRoot() {
-  // skills/evolver -> workspace root
-  return path.resolve(getRepoRoot(), '..', '..');
+  // Prioritize environment variable
+  if (process.env.OPENCLAW_WORKSPACE) {
+    return process.env.OPENCLAW_WORKSPACE;
+  }
+  
+  // Try to find workspace directory relative to repo root
+  const repoRoot = getRepoRoot();
+  const workspaceDir = path.join(repoRoot, 'workspace');
+  if (fs.existsSync(workspaceDir)) {
+    return workspaceDir;
+  }
+  
+  // Fallback: assume evolver is at skills/evolver, go up 2 levels
+  return path.resolve(__dirname, '..', '..', '..', '..');
 }
 
 function getLogsDir() {
@@ -83,4 +112,3 @@ module.exports = {
   getEvolutionPrinciplesPath,
   getReflectionLogPath,
 };
-


### PR DESCRIPTION
## Problem

When evolver is installed as a skill inside another git repository (e.g., OpenClaw workspace at `workspace/skills/evolver`), it has its own `.git` directory. This causes issues:

1. Git operations (diff, rollback) only see changes within evolver's own directory
2. Evolution changes to other parts of the workspace are not tracked
3. Blast radius calculations miss files outside evolver's repo

## Solution

This PR adds flexible git repository detection:

1. **Environment variable override**: 
   - `EVOLVER_REPO_ROOT` - explicitly set the repo root
   - `OPENCLAW_WORKSPACE` - explicitly set the workspace directory

2. **Auto-detection**: Walk up the directory tree to find the nearest `.git` directory

3. **Backward compatible**: Falls back to original behavior if no parent git repo found

## Usage

```bash
# Option 1: Environment variables
export EVOLVER_REPO_ROOT=/path/to/parent/repo
export OPENCLAW_WORKSPACE=/path/to/workspace

# Option 2: Remove nested .git, let auto-detection work
rm -rf workspace/skills/evolver/.git
```

## Testing

```bash
# With parent .git at /Users/user/.openclaw
cd workspace/skills/evolver
node -e "console.log(require('./src/gep/paths').getRepoRoot())"
# Output: /Users/user/.openclaw (parent repo)
```

## Use Case

OpenClaw users install evolver as a skill inside their workspace. The workspace is tracked by a parent git repo. This PR allows evolver to correctly operate on the parent repo for change tracking and rollback.