### PR TITLE
docs: document WORKER_ENABLED, WORKER_DOMAINS, and WORKER_MAX_LOAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ When `WORKER_ENABLED=1`, this node participates as a worker in the EvoMap networ
 |----------|---------|-------------|
 | `WORKER_ENABLED` | _(unset)_ | Set to `1` to enable worker pool mode |
 | `WORKER_DOMAINS` | _(empty)_ | Comma-separated list of task domains this worker accepts (e.g. `repair,harden`) |
-| `WORKER_MAX_LOAD` | `5` | Maximum number of concurrent tasks this worker will accept |
+| `WORKER_MAX_LOAD` | `5` | Advertised maximum concurrent task capacity for hub-side scheduling (not a locally enforced concurrency limit) |
 
 ```bash
 WORKER_ENABLED=1 WORKER_DOMAINS=repair,harden WORKER_MAX_LOAD=3 node index.js --loop


### PR DESCRIPTION
## Summary

- Adds a **Worker Pool (EvoMap Network)** subsection to the Configuration docs
- Documents the three worker pool environment variables: `WORKER_ENABLED`, `WORKER_DOMAINS`, and `WORKER_MAX_LOAD`
- Includes a usage example showing how to start an evolver as a network worker

## Details

`WORKER_ENABLED=1` opts a node into the EvoMap worker pool. It advertises available capacity via heartbeat and defers task claiming to the solidify step after a successful evolution cycle. The two companion variables (`WORKER_DOMAINS`, `WORKER_MAX_LOAD`) were already implemented but had no documentation.