### PR TITLE
fix: avoid loop deadlock when bridge is disabled

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,37 @@ function readJsonSafe(p) {
   }
 }
 
+function rejectPendingRun(statePath) {
+  try {
+    const { getRepoRoot } = require('./src/gep/paths');
+    const { execSync } = require('child_process');
+    const repoRoot = getRepoRoot();
+
+    execSync('git checkout -- .', { cwd: repoRoot, encoding: 'utf8', timeout: 30000 });
+    execSync('git clean -fd', { cwd: repoRoot, encoding: 'utf8', timeout: 30000 });
+  } catch (e) {
+    console.warn('[Loop] Pending run rollback failed: ' + (e.message || e));
+  }
+
+  try {
+    const state = readJsonSafe(statePath);
+    if (state && state.last_run && state.last_run.run_id) {
+      state.last_solidify = {
+        run_id: state.last_run.run_id,
+        rejected: true,
+        reason: 'loop_bridge_disabled_autoreject',
+        timestamp: new Date().toISOString(),
+      };
+      fs.writeFileSync(statePath, JSON.stringify(state, null, 2) + '\n', 'utf8');
+      return true;
+    }
+  } catch (e) {
+    console.warn('[Loop] Failed to clear pending run state: ' + (e.message || e));
+  }
+
+  return false;
+}
+
 function isPendingSolidify(state) {
   const lastRun = state && state.last_run ? state.last_run : null;
   const lastSolid = state && state.last_solidify ? state.last_solidify : null;
@@ -136,6 +167,16 @@ async function main() {
           try {
             await evolve.run();
             ok = true;
+
+            if (String(process.env.EVOLVE_BRIDGE || '').toLowerCase() === 'false') {
+              const stAfterRun = readJsonSafe(solidifyStatePath);
+              if (isPendingSolidify(stAfterRun)) {
+                const cleared = rejectPendingRun(solidifyStatePath);
+                if (cleared) {
+                  console.warn('[Loop] Auto-rejected pending run because bridge is disabled in loop mode.');
+                }
+              }
+            }
           } catch (error) {
             const msg = error && error.message ? String(error.message) : String(error);
             console.error(`Evolution cycle failed: ${msg}`);


### PR DESCRIPTION
## Summary

Prevent `node index.js --loop` from getting stuck forever when `EVOLVE_BRIDGE=false`.

## Problem

`--loop` mode forces `EVOLVE_BRIDGE=false`, but it still uses the `last_run` / `last_solidify` gating logic.

In non-bridge mode, `evolve.run()` does not automatically run `solidify`. It only prints the prompt and expects a manual `node index.js solidify`.

That means loop mode can:

1. write `last_run`
2. leave `last_solidify` unset
3. block all later loop iterations in the pending-solidify sleep path

The daemon stays alive, but it stops making progress.

## Fix

After a loop cycle finishes, if bridge is disabled and the run still left a pending solidify state, automatically reject that pending run:

- roll back tracked/untracked changes
- write `last_solidify` for the same `run_id`
- log why the pending run was cleared

## Why this approach

The current loop contract already disables bridge mode. Given that behavior, loop mode should not leave behind a state that requires a manual solidify step the daemon will never perform itself.

This keeps internal daemon mode moving forward without changing the existing bridge/non-bridge split.

## Validation

- `git diff --check`
- `node -e "require('./index.js')"`
