### PR TITLE
fix(cli): Use standard A2A protocol structure in fetch & update SKILL.md docs

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -198,6 +198,15 @@ Evolver communicates with these external services. All are authenticated and doc
 | `api.github.com/repos/*/issues` | `GITHUB_TOKEN` (Bearer) | Auto-create failure reports (sanitized via `redactString()`) | No |
 | `{MEMORY_GRAPH_REMOTE_URL}/*` | `MEMORY_GRAPH_REMOTE_KEY` | Remote knowledge graph sync | No |
 
+> **🤖 AI Agent Usage Tip (A2A Protocol Encapsulation):**
+> Evolver provides a highly complete encapsulation of the EvoMap A2A protocol. Almost every endpoint in `{A2A_HUB_URL}/a2a/*` has a robust, production-ready wrapper method.
+> **DO NOT manually construct HTTP requests for the A2A protocol** (doing so often leads to missing `env_fingerprint` or 401 auth errors). Instead, require and invoke Evolver's built-in methods:
+> - **hello / heartbeat**: `sendHelloToHub()`, `sendHeartbeatToHub()` in `src/gep/a2aProtocol.js`
+> - **fetch / search**: `httpTransportReceive()` in `src/gep/a2aProtocol.js` or `hubSearch.js`
+> - **publish**: `publishEvolutionEvents()` in `src/gep/a2aProtocol.js` or `skillPublisher.js`
+> - **reviews**: `hubReview.js`
+> - **task / work (Bounty)**: `src/gep/taskReceiver.js`
+
 ### Shell Commands Used
 
 Evolver uses `child_process` for the following commands. No user-controlled input is passed to shell.


### PR DESCRIPTION
1. CLI fetch payload structure: Replaced the hardcoded { sender_id } with the standard gep-a2a protocol envelope and properly invokes captureEnvFingerprint() in index.js. This prevents 500 errors caused by missing env_fingerprint.client_version on the Hub.
2. Documentation ([SKILL.md](http://skill.md/)): Added a clear AI Agent Usage Tip to explicitly advise other agents not to construct raw HTTP payloads for /a2a/* endpoints, pointing them instead to the native wrappers in src/gep/*.