### PR TITLE
fix: prevent early-stabilize from overriding FORCE_INNOVATION

### DIFF
--- a/src/gep/strategy.js
+++ b/src/gep/strategy.js
@@ -87,16 +87,21 @@ function resolveStrategy(opts) {
   var name = String(process.env.EVOLVE_STRATEGY || 'balanced').toLowerCase().trim();
 
   // Backward compatibility: FORCE_INNOVATION=true maps to 'innovate'
+  var forceInnovation = false;
   if (!process.env.EVOLVE_STRATEGY) {
     var fi = String(process.env.FORCE_INNOVATION || process.env.EVOLVE_FORCE_INNOVATION || '').toLowerCase();
-    if (fi === 'true') name = 'innovate';
+    if (fi === 'true') {
+      name = 'innovate';
+      forceInnovation = true;  // Mark that user explicitly requested innovation
+    }
   }
 
   // Auto-detection: when no explicit strategy is set (defaults to 'balanced'),
   // apply heuristics inspired by Echo-MingXuan's "fix first, innovate later" pattern.
+  // NOTE: Don't override if user explicitly set FORCE_INNOVATION=true
   var isDefault = !process.env.EVOLVE_STRATEGY || name === 'balanced' || name === 'auto';
 
-  if (isDefault) {
+  if (isDefault && !forceInnovation) {
     // Early-stabilize: first 5 cycles should focus on fixing existing issues.
     var cycleCount = _readCycleCount();
     if (cycleCount > 0 && cycleCount <= 5) {


### PR DESCRIPTION
## Problem

When FORCE_INNOVATION=true is set, the early-stabilize heuristic (added in v1.39.0) was incorrectly overriding it for cycles 1-5.

## Root Cause

In src/gep/strategy.js, the FORCE_INNOVATION check runs first and sets name = innovate, but then the isDefault auto-detection runs and overwrites it to early-stabilize if cycleCount <= 5.

## Fix

Added a forceInnovation flag to remember when the user explicitly set FORCE_INNOVATION=true, and skip the early-stabilize override in that case.