### PR TITLE
Fix license badge and add GitHub topics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🧬 Evolver
 
 [![GitHub stars](https://img.shields.io/github/stars/EvoMap/evolver?style=social)](https://github.com/EvoMap/evolver/stargazers)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: GPL-3.0](https://img.shields.io/badge/License-GPL--3.0-blue.svg)](https://opensource.org/licenses/GPL-3.0)
 [![Node.js >= 18](https://img.shields.io/badge/Node.js-%3E%3D%2018-green.svg)](https://nodejs.org/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/EvoMap/evolver)](https://github.com/EvoMap/evolver/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/EvoMap/evolver)](https://github.com/EvoMap/evolver/issues)


### PR DESCRIPTION
## Summary

Fixes two issues from #398 — a quick housekeeping PR with high impact for discoverability and contributor trust.

## Changes

1. **Fix license badge**: README badge incorrectly said "MIT" but the repo is licensed under GPL-3.0. Updated to 
2. **Add GitHub topics**: The repo had zero topics, leaving significant discoverability on the table. Added: , , , , , , 

## Why It Matters

- License mismatch deters enterprise contributors who check the LICENSE file first
- GitHub topics are free discoverability — the repo appears in topic searches instead of only direct URL traffic