### PR TITLE
fix(lifecycle): remove wrapper path filter from getRunningPids()

### DIFF
--- a/src/ops/lifecycle.js
+++ b/src/ops/lifecycle.js
@@ -34,9 +34,7 @@ function getRunningPids() {
             var cmd = parts.slice(1).join(' ');
             if (pid === process.pid) continue;
             if (cmd.includes('node') && cmd.includes('index.js') && cmd.includes('--loop')) {
-                if (cmd.includes('feishu-evolver-wrapper') || cmd.includes('skills/evolver')) {
-                    pids.push(pid);
-                }
+                pids.push(pid);
             }
         }
         return [...new Set(pids)].filter(isPidRunning);


### PR DESCRIPTION
## Problem

`getRunningPids()` was filtering by specific wrapper paths:


This excluded any evolver process launched via:
- launchd/plist (bash wrapper: `cd /Users/njiang/evolver && /opt/homebrew/bin/node index.js --loop`)
- direct node invocations without the specific wrapper paths

Result: `status()` and `checkHealth()` returned `running: false` even when evolver was actively running.

## Fix

Remove the wrapper-path whitelist filter. Any process matching `node` + `index.js` + `--loop` is a valid evolver loop regardless of how it was launched.



## Testing

`status()` and `checkHealth()` now correctly detect evolver running under launchd.

---

**Before**: `running: false` (incorrect)
**After**: `running: true, pids: [bash-wrapper-pid, node-pid]` (correct)