### PR TITLE
fix(issueReporter): stabilize auto-issue dedup and cooldown logic

### DIFF
--- a/src/gep/issueReporter.js
+++ b/src/gep/issueReporter.js
@@ -60,6 +60,10 @@ function truncateNodeId(nodeId) {
 }
 
 function computeErrorKey(signals) {
+  // Normalize occurrence-specific prefixes so the same underlying error
+  // yields a stable key across re-emissions. Without this, recurring_errsig
+  // carries an (Nx) count that changes every cycle and defeats recentIssueKeys
+  // deduplication.
   const relevant = signals
     .filter(function (s) {
       return s.startsWith('recurring_errsig') ||
@@ -67,6 +71,9 @@ function computeErrorKey(signals) {
         s === 'recurring_error' ||
         s === 'failure_loop_detected' ||
         s === 'high_failure_ratio';
+    })
+    .map(function (s) {
+      return s.replace(/^recurring_errsig\(\d+x\):/, 'recurring_errsig:');
     })
     .sort()
     .join('|');
@@ -177,8 +184,11 @@ function shouldReport(signals, config) {
 
   if (!hasFailureLoop && !hasRecurringAndHigh) return false;
 
+  // Enforce the configured minimum streak. Previously this short-circuited
+  // only when the streak signal was present; if a caller omitted the
+  // consecutive_failure_streak_N signal we'd silently bypass the gate.
   const streakCount = extractStreakCount(signals);
-  if (streakCount > 0 && streakCount < config.minStreak) return false;
+  if (streakCount < config.minStreak) return false;
 
   const state = readState();
   const errorKey = computeErrorKey(signals);
@@ -244,10 +254,15 @@ async function findExistingIssue(repo, title, token) {
   let data;
   try { data = await response.json(); } catch (_) { return null; }
   const items = Array.isArray(data && data.items) ? data.items : [];
+  // Prefer exact-title match; otherwise fall back to strict prefix match
+  // against our own auto-issue title sentinel. The old substring fallback
+  // matched unrelated issues whose body had been edited into the title.
+  const AUTO_PREFIX = '[Auto] Recurring failure: ';
   const match = items.find(function (it) {
     return it && typeof it.title === 'string' && it.title.trim() === title.trim() && it.state === 'open';
   }) || items.find(function (it) {
-    return it && it.state === 'open' && typeof it.title === 'string' && it.title.indexOf(titleSig) !== -1;
+    return it && it.state === 'open' && typeof it.title === 'string' &&
+      it.title.startsWith(AUTO_PREFIX) && it.title.trim().startsWith(titleSig.trim());
   });
   if (!match) return null;
   return { number: match.number, url: match.html_url, title: match.title };
@@ -281,8 +296,12 @@ async function maybeReportIssue(opts) {
       let recentKeys = Array.isArray(state.recentIssueKeys) ? state.recentIssueKeys : [];
       if (!recentKeys.includes(errorKey)) recentKeys.push(errorKey);
       if (recentKeys.length > 20) recentKeys = recentKeys.slice(-20);
+      // Do NOT bump lastReportedAt on the skip branch. We did not file a
+      // new issue, and rewriting the timestamp here would continually
+      // reset the cooldown clock every cycle and suppress future reports
+      // indefinitely while the existing issue stayed open.
       writeState({
-        lastReportedAt: new Date().toISOString(),
+        lastReportedAt: state.lastReportedAt || null,
         recentIssueKeys: recentKeys,
         lastIssueUrl: existing.url,
         lastIssueNumber: existing.number,
@@ -310,4 +329,13 @@ async function maybeReportIssue(opts) {
   }
 }
 
-module.exports = { maybeReportIssue, buildIssueBody, shouldReport, findExistingIssue };
+module.exports = {
+  maybeReportIssue,
+  buildIssueBody,
+  shouldReport,
+  findExistingIssue,
+  // Internals exposed so unit tests can cover dedup, streak, and key stability.
+  computeErrorKey,
+  extractStreakCount,
+  extractErrorSignature,
+};

--- a/test/issueReporter.test.js
+++ b/test/issueReporter.test.js
@@ -77,6 +77,48 @@ function jsonResponse(body, status) {
     assert.strictEqual(called, false, 'fetch should not be called for empty title');
   });
 
+  // Case 7: computeErrorKey is stable across occurrence counts
+  // (regression: (Nx) prefix had been hashed verbatim, mutating the key
+  // every cycle and defeating recentIssueKeys dedup).
+  const { computeErrorKey } = require('../src/gep/issueReporter');
+  const k3 = computeErrorKey(['recurring_errsig(3x):timeout on API', 'failure_loop_detected']);
+  const k4 = computeErrorKey(['recurring_errsig(4x):timeout on API', 'failure_loop_detected']);
+  const k5 = computeErrorKey(['recurring_errsig(5x):timeout on API', 'failure_loop_detected']);
+  assert.strictEqual(k3, k4, 'errorKey should be stable across (Nx) counts');
+  assert.strictEqual(k4, k5, 'errorKey should be stable across (Nx) counts');
+
+  // Case 8: shouldReport enforces minStreak even when the streak signal is
+  // absent (regression: prior "streakCount > 0 && < minStreak" guard was a
+  // no-op when the consecutive_failure_streak_N signal was missing).
+  const { shouldReport } = require('../src/gep/issueReporter');
+  const gatedCfg = { repo: 'x/y', cooldownMs: 86400000, minStreak: 5 };
+  assert.strictEqual(
+    shouldReport(['failure_loop_detected', 'recurring_errsig(2x):foo'], gatedCfg),
+    false,
+    'minStreak gate must apply when streak signal is absent'
+  );
+  assert.strictEqual(
+    shouldReport(['failure_loop_detected', 'recurring_errsig(2x):foo', 'consecutive_failure_streak_10'], gatedCfg),
+    true,
+    'should pass when streak meets minStreak'
+  );
+
+  // Case 9: findExistingIssue no longer matches unrelated titles via loose
+  // substring fallback (regression: prior it.title.indexOf(titleSig) !== -1
+  // matched issues that merely contained the search signature).
+  await withFetchMock(async function () {
+    return jsonResponse({
+      items: [
+        { number: 12345, state: 'open', html_url: 'https://x/y/12345',
+          title: 'META: [Auto] Recurring failure: boom — discussion thread about unrelated context that embeds the above substring' }
+      ],
+    });
+  }, async function () {
+    const target = '[Auto] Recurring failure: boom';
+    const result = await findExistingIssue('x/y', target, 'faketoken');
+    assert.strictEqual(result, null, 'substring fallback must not match unrelated titles');
+  });
+
   console.log('issueReporter.test.js: OK');
 })().catch(function (err) {
   console.error(err);


### PR DESCRIPTION
## Problem

Four interacting bugs in `src/gep/issueReporter.js` combine to defeat the
module's own purpose. The symptoms are already visible on this tracker:
issues #395, #396, #397, and #404 are identical auto-filed duplicates
that the reporter was supposed to suppress.

1. **`computeErrorKey` hashes the occurrence count.** It feeds signals
   like `recurring_errsig(3x):timeout in API call` and
   `recurring_errsig(4x):timeout in API call` verbatim into SHA-256, so
   the same underlying error produces a different key every emission.
   `recentIssueKeys.includes(errorKey)` can never match.

2. **`shouldReport` bypasses the `minStreak` gate when the streak
   signal is absent.** `extractStreakCount` returns `0` when no
   `consecutive_failure_streak_N` signal is present, and the
   `streakCount > 0 && streakCount < minStreak` guard short-circuits.
   Users who raise `EVOLVER_ISSUE_MIN_STREAK` still get early reports.

3. **`maybeReportIssue` resets `lastReportedAt` on the skip branch.**
   When `findExistingIssue` returns an existing open issue, the code
   logs "skipping duplicate" but still writes
   `lastReportedAt: new Date().toISOString()`. The cooldown check then
   sees a freshly-bumped timestamp, so as long as the existing open
   issue stays open, no re-report is ever possible.

4. **`findExistingIssue` substring fallback matches unrelated
   titles.** The fallback `it.title.indexOf(titleSig) !== -1` matches
   any title that merely contains the signature as a substring.

`computeErrorKey`, `extractStreakCount`, and `extractErrorSignature`
were not exported, which is how all three bugs in category (1)–(3)
shipped without test coverage.

## Fix

- Normalize the `recurring_errsig(Nx):` prefix inside `computeErrorKey`
  (uses the same regex that `extractErrorSignature` already uses).
- Drop the `> 0` precondition from the `minStreak` gate.
- Preserve the prior `lastReportedAt` on the skip branch; only
  `lastSkippedAt` and `recentIssueKeys` are updated.
- Replace the substring fallback with a prefix check that requires
  both the auto-issue prefix and the same signature.
- Export the three helpers so the regressions can be covered.

## Testing

```
$ node test/issueReporter.test.js
```

Against `main` with the new test cases (added in this PR):

```
TypeError: computeErrorKey is not a function
    at run (/.../test/issueReporter.test.js:84:14)
```

With this PR applied:

```
issueReporter.test.js: OK
```

The three new test cases cover:

- `computeErrorKey` is stable across `(3x)`, `(4x)`, `(5x)` prefixes.
- `shouldReport(minStreak=5)` returns `false` when the streak signal is
  missing, and `true` when the streak meets the minimum.
- `findExistingIssue` does not match a title that contains the search
  signature as an unrelated substring.

## Scope

- `src/gep/issueReporter.js` — 4 focused edits, no behaviour change
  outside the bug paths; module exports gain three helpers (additive).
- `test/issueReporter.test.js` — three new cases.

No changes to obfuscated modules. No config changes. No new
dependencies.

## Follow-ups (not in this PR)

- `DEFAULT_REPO = 'autogame-17/capability-evolver'` legacy handle —
  separate issue.
- `sanitize.js` pattern gaps (Slack, JWT, Azure, Discord) — separate
  issue.