### PR TITLE
fix(scripts): remove unreachable branch in validate-modules.js

### DIFF
--- a/scripts/validate-modules.js
+++ b/scripts/validate-modules.js
@@ -21,17 +21,12 @@ for (const m of modules) {
     process.exit(1);
   }
 
-  if (t === 'object') {
-    const keys = Object.keys(exported);
-    for (const k of keys) {
-      if (typeof exported[k] === 'function') {
-        if (typeof exported[k] !== 'function') {
-          console.error('FAIL: ' + m + '.' + k + ' is declared but not a callable function');
-          process.exit(1);
-        }
-      }
-    }
-  }
+  // Previously this block contained a nested `typeof === 'function'` test
+  // inside `typeof === 'function'`, which was trivially false and made the
+  // intended "declared but not callable" warning unreachable. Without a
+  // declaration manifest we cannot tell which exported keys are expected
+  // to be functions, so the block is left as a no-op but the dead branch
+  // is removed to avoid giving false assurance.
   checked++;
 }
 


### PR DESCRIPTION
## Problem

`scripts/validate-modules.js:27-28`:

```js
for (const k of keys) {
  if (typeof exported[k] === 'function') {
    if (typeof exported[k] !== 'function') {
      console.error('FAIL: ' + m + '.' + k + ' is declared but not a callable function');
      process.exit(1);
    }
  }
}
```

The inner `typeof !== 'function'` can never be true under the outer
`typeof === 'function'`, so the \"declared but not callable\" error is
unreachable and the validator silently accepts everything it claims to
check. The script is in the package because of a comment on line 3
(\"exported functions are callable (typeof check)\") that the code does
not actually enforce.

## Fix

Without a manifest of expected function keys the script cannot decide
which exported members ought to be functions, so the nested block is
removed rather than given a fake fix. Behaviour is unchanged — in
practice the original block never produced any output — but the code
now matches that behaviour honestly and stops giving false assurance
to readers.

## Testing

```
$ node scripts/validate-modules.js ./src/gep/issueReporter
ok: 1 module(s) validated
```

Output is identical before and after this change for every module the
script is invoked with.

## Scope

One file, -11/+6.