### PR TITLE
docs: align README license to GPL-3.0-or-later

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # 🧬 Evolver
 
 [![GitHub stars](https://img.shields.io/github/stars/EvoMap/evolver?style=social)](https://github.com/EvoMap/evolver/stargazers)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Node.js >= 18](https://img.shields.io/badge/Node.js-%3E%3D%2018-green.svg)](https://nodejs.org/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/EvoMap/evolver)](https://github.com/EvoMap/evolver/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/EvoMap/evolver)](https://github.com/EvoMap/evolver/issues)
@@ -425,6 +425,6 @@ Clone it into any directory you like. If you use [OpenClaw](https://openclaw.com
 
 ## License
 
-[MIT](https://opensource.org/licenses/MIT)
+[GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0)
 
 > Core evolution engine modules are distributed in obfuscated form to protect intellectual property. Source: [EvoMap/evolver](https://github.com/EvoMap/evolver).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # 🧬 Evolver
 
 [![GitHub stars](https://img.shields.io/github/stars/EvoMap/evolver?style=social)](https://github.com/EvoMap/evolver/stargazers)
-[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://opensource.org/licenses/MIT)
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Node.js >= 18](https://img.shields.io/badge/Node.js-%3E%3D%2018-green.svg)](https://nodejs.org/)
 [![GitHub last commit](https://img.shields.io/github/last-commit/EvoMap/evolver)](https://github.com/EvoMap/evolver/commits/main)
 [![GitHub issues](https://img.shields.io/github/issues/EvoMap/evolver)](https://github.com/EvoMap/evolver/issues)
@@ -421,4 +421,4 @@ MAJOR.MINOR.PATCH
 
 ## 许可证
 
-[MIT](https://opensource.org/licenses/MIT)
+[GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0)


### PR DESCRIPTION
## Problem

The license is declared four times and the declarations do not agree:

| Location | Value |
|---|---|
| `README.md:4` (shields badge) | MIT |
| `README.md:428` (Section \"License\") | MIT |
| `README.zh-CN.md:4` | MIT |
| `README.zh-CN.md:424` | MIT |
| `package.json:20` | `\"license\": \"GPL-3.0-or-later\"` |
| `LICENSE` | GNU General Public License, Version 3 |

See #407 for the full rationale.

## Fix

This PR aligns the four README locations to the authoritative
declaration already present in the LICENSE file and `package.json`.

- Shields badge targets `https://www.gnu.org/licenses/gpl-3.0`.
- License section in both languages reads `GPL-3.0-or-later`.

## Why this direction

Three signals point to GPL-3.0 as the intended license:

1. **LICENSE file is legally binding** for redistribution. It contains
   the full GPL-3.0 text, not an MIT text.
2. **`package.json:20`** uses the SPDX identifier
   `GPL-3.0-or-later`, which is what npm, SPDX scanners, and GitHub's
   dependency graph record.
3. **Obfuscated release artifacts** (`src/gep/*.js`) imply that the
   publisher is exercising GPL-3.0 §6 terms for object-code
   distribution; that is not a posture the MIT license contemplates.

If MIT is actually the intended license, the direction should be
reversed: LICENSE and package.json would change instead. Aligning the
README to the LICENSE file is the safer default — the README is
documentation, the LICENSE file is the contract with redistributors.

## Testing

Markdown only. No runtime behaviour change.

```
$ grep -n -i \"license\" README.md README.zh-CN.md | head
README.md:4:[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
README.md:426:## License
README.md:428:[GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0)
README.zh-CN.md:4:[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
README.zh-CN.md:424:[GPL-3.0-or-later](https://www.gnu.org/licenses/gpl-3.0)
```

## Scope

Two files, +4/−4 lines.

Closes #407.