### PR TITLE
security: add Slack, JWT, Azure, and Discord patterns to sanitize.js

### DIFF
--- a/src/gep/sanitize.js
+++ b/src/gep/sanitize.js
@@ -24,6 +24,14 @@ const REDACT_PATTERNS = [
   /sk-ant-[A-Za-z0-9\-_]{20,}/g,
   // npm tokens
   /npm_[A-Za-z0-9]{36,}/g,
+  // Slack tokens (bot/user/app/refresh/verification)
+  /xox[baprsv]-[A-Za-z0-9-]{10,}/g,
+  // JSON Web Tokens (header.payload.signature)
+  /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]{20,}/g,
+  // Azure storage connection strings (redact the key field only)
+  /AccountKey=[^;\s]+/gi,
+  // Discord bot tokens (3 base64url segments: 24+ / 6+ / 27+ chars)
+  /\b[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,}\b/g,
   // Private keys
   /-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g,
   // Basic auth in URLs (redact only credentials, keep :// and @)
@@ -75,6 +83,10 @@ const LEAK_SCANNERS = [
   { type: 'github_token', pattern: /ghp_[A-Za-z0-9]{36,}/g, suggest: 'process.env.GITHUB_TOKEN' },
   { type: 'github_token', pattern: /github_pat_[A-Za-z0-9_]{22,}/g, suggest: 'process.env.GITHUB_TOKEN' },
   { type: 'npm_token', pattern: /npm_[A-Za-z0-9]{36,}/g, suggest: 'process.env.NPM_TOKEN' },
+  { type: 'slack_token', pattern: /xox[baprsv]-[A-Za-z0-9-]{10,}/g, suggest: 'process.env.SLACK_TOKEN' },
+  { type: 'jwt', pattern: /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]{20,}/g, suggest: 'process.env.JWT' },
+  { type: 'azure_key', pattern: /AccountKey=[^;\s]+/gi, suggest: 'process.env.AZURE_STORAGE_KEY' },
+  { type: 'discord_token', pattern: /\b[MN][A-Za-z0-9]{23}\.[\w-]{6}\.[\w-]{27,}\b/g, suggest: 'process.env.DISCORD_TOKEN' },
   { type: 'bearer_token', pattern: /Bearer\s+[A-Za-z0-9\-._~+\/]{20,}=*/g, suggest: 'process.env.AUTH_TOKEN' },
   { type: 'private_key', pattern: /-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g, suggest: 'process.env.PRIVATE_KEY_PATH' },
   // Database connection strings with credentials

--- a/src/gep/sanitize.js
+++ b/src/gep/sanitize.js
@@ -30,8 +30,13 @@ const REDACT_PATTERNS = [
   /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]{20,}/g,
   // Azure storage connection strings (redact the key field only)
   /AccountKey=[^;\s]+/gi,
-  // Discord bot tokens (3 base64url segments: 24+ / 6+ / 27+ chars)
-  /\b[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{27,}\b/g,
+  // Discord bot tokens. Three base64url segments:
+  //   1. 24+ chars starting with [MNO] (user-id snowflake, base64-encoded)
+  //   2. exactly 6 chars (timestamp)
+  //   3. 27+ chars (HMAC signature)
+  // Requiring an uppercase leading char avoids false-matching dotted
+  // lowercase identifiers (Python module paths, hostnames, etc.).
+  /\b[MNO][A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g,
   // Private keys
   /-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g,
   // Basic auth in URLs (redact only credentials, keep :// and @)
@@ -86,7 +91,7 @@ const LEAK_SCANNERS = [
   { type: 'slack_token', pattern: /xox[baprsv]-[A-Za-z0-9-]{10,}/g, suggest: 'process.env.SLACK_TOKEN' },
   { type: 'jwt', pattern: /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]{20,}/g, suggest: 'process.env.JWT' },
   { type: 'azure_key', pattern: /AccountKey=[^;\s]+/gi, suggest: 'process.env.AZURE_STORAGE_KEY' },
-  { type: 'discord_token', pattern: /\b[MN][A-Za-z0-9]{23}\.[\w-]{6}\.[\w-]{27,}\b/g, suggest: 'process.env.DISCORD_TOKEN' },
+  { type: 'discord_token', pattern: /\b[MNO][A-Za-z0-9_-]{23,}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}\b/g, suggest: 'process.env.DISCORD_TOKEN' },
   { type: 'bearer_token', pattern: /Bearer\s+[A-Za-z0-9\-._~+\/]{20,}=*/g, suggest: 'process.env.AUTH_TOKEN' },
   { type: 'private_key', pattern: /-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g, suggest: 'process.env.PRIVATE_KEY_PATH' },
   // Database connection strings with credentials


### PR DESCRIPTION
## Problem

`src/gep/sanitize.js::redactString` is the last line of defense
before session log excerpts (up to 2,000 chars) and per-event
`reason` strings are posted to `config.repo` by
`src/gep/issueReporter.js`. It already covers OpenAI `sk-`, GitHub
`gh[pousr]_`, AWS `AKIA…`, npm `npm_`, generic `Bearer`, and a few
others. It was missing four common formats.

See #409 for reproduction and the full rationale.

| Format | Example |
|---|---|
| Slack bot/user tokens | `xoxb-…`, `xoxp-…` |
| JWT (header.payload.signature) | `eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sflKxw…` |
| Azure storage connection strings | `DefaultEndpointsProtocol=https;AccountName=…;AccountKey=…` |
| Discord bot tokens | `ODY4…YPc-6Q…` |

These formats show up routinely in agent runtime logs (Slack
webhooks, OIDC `id_token` responses, Azure Storage SDK debug logs,
bot frameworks), so without these patterns any of them landing in a
gene's `outcome.reason` or in a session log reaches GitHub in
cleartext.

## Fix

- Add four regexes to `REDACT_PATTERNS` (destructive replace).
- Add four matching entries to `LEAK_SCANNERS` (non-destructive
  detection) so the existing scanner reports the same categories.

Scope: `src/gep/sanitize.js`, +12 lines, no behaviour change outside
the matched substrings.

## Testing

```
$ node test/sanitize.test.js
All sanitize tests passed (34 assertions)
```

Reproduction (uses 4 synthetic secrets in the public test):

```js
const { redactString } = require('./src/gep/sanitize');
const samples = [
  'xoxb-1234567890-1234567890123-AbCdEfGhIjKlMnOpQrStUvWx',
  'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.sflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c',
  'DefaultEndpointsProtocol=https;AccountName=acct;AccountKey=ABC123DEF456ghi789JKL==;EndpointSuffix=core.windows.net',
  'ODY4MzE2NTg4ODIwMTEyMzQ1.YPc-6Q.K3n1tfY9q9f4k_5vZl3Mw2X1AbCdefGhIjK',
];
for (const s of samples) console.log(redactString(s) === s ? 'LEAKED' : 'REDACTED');
```

Before this PR:

```
LEAKED
LEAKED
LEAKED
LEAKED
```

After this PR:

```
REDACTED
REDACTED
REDACTED
REDACTED
```

## Prior art

PR #107 (`fix: harden sanitize patterns for token leakage
prevention`) attempted a similar hardening and was closed without
merge on 2026-02-26. This PR keeps the scope minimal — four additive
regexes, no refactor, no reorder of existing patterns — so reviewers
can approve or deny each pattern independently. Happy to split
further if that helps.

Closes #409.