### PR TITLE
docs(SKILL): declare evomap.ai in network allow-list and network_endpoints

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -12,12 +12,12 @@ metadata:
   capabilities:
     allow:
       - execute: [git, node, npm]
-      - network: [127.0.0.1, api.github.com]
+      - network: [127.0.0.1, api.github.com, evomap.ai]
       - read: [workspace/**]
       - write: [workspace/assets/**, workspace/memory/**]
     deny:
       - execute: ["!git", "!node", "!npm", "!ps", "!pgrep", "!df"]
-      - network: ["!127.0.0.1", "!api.github.com"]
+      - network: ["!127.0.0.1", "!api.github.com", "!evomap.ai"]
   env_declarations:
     - name: A2A_NODE_ID
       required: true
@@ -57,6 +57,10 @@ metadata:
     - host: api.github.com
       purpose: Release creation, changelog publishing, auto-issue reporting
       auth: GITHUB_TOKEN (Bearer)
+      optional: true
+    - host: evomap.ai
+      purpose: EvoMap Hub (A2A protocol). Contacted directly by privacyClient, taskReceiver, and skillPublisher when A2A_HUB_URL defaults are used.
+      auth: A2A_NODE_SECRET (Bearer)
       optional: true
   file_access:
     reads:


### PR DESCRIPTION
## Problem

`SKILL.md` declares the network allow-list as
`[127.0.0.1, api.github.com]` and the `network_endpoints` section
lists only those two hosts. Readable code paths in this repo contact
`https://evomap.ai` directly:

```
src/gep/privacyClient.js:10     const HUB_URL = process.env.A2A_HUB_URL || process.env.EVOMAP_HUB_URL || 'https://evomap.ai';
src/gep/taskReceiver.js:11      (same)
src/gep/skillPublisher.js:162   ... https://evomap.ai/terms ...
```

`env_declarations` also documents `A2A_HUB_URL` default as
`https://evomap.ai` (line 27), so `evomap.ai` is an intended
endpoint; the network-allow-list just does not reflect it. See #411
for the full rationale.

## Fix

Add `evomap.ai` to:

- `capabilities.allow.network`
- `capabilities.deny.network` (as `!evomap.ai` to match the existing
  deny-list convention)
- `network_endpoints` with purpose, auth, and `optional: true`

This is a documentation change only; runtime behaviour is unchanged.

## Alternative (not in this PR)

If the project intends all `evomap.ai` traffic to go through the
local Proxy — the comment on the `127.0.0.1 (Proxy)` endpoint says
`"All EvoMap interactions go through local Proxy mailbox"` — then the
right fix is to change `privacyClient.js` / `taskReceiver.js` to
route through `127.0.0.1` instead of calling the hostname directly.
In that case this doc PR should be rejected and I can submit the
code PR instead. Please indicate which direction you prefer.

## Testing

Markdown / YAML only. No runtime behaviour change. The affected
modules already hit `evomap.ai` today; this PR only updates the
policy declaration so sandbox orchestrators can validate the traffic.

## Scope

One file, +6/−2.

Closes #411.