### PR TITLE
fix(ops): cross-platform lifecycle and health_check (#379)

### DIFF
--- a/src/ops/health_check.js
+++ b/src/ops/health_check.js
@@ -1,13 +1,20 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execSync } = require('child_process');
+
+function getDefaultMount() {
+    if (process.platform === 'win32') {
+        return path.parse(process.cwd()).root || 'C:\\';
+    }
+    return '/';
+}
 
 function getDiskUsage(mount) {
     try {
+        const targetMount = mount || getDefaultMount();
         // Use Node 18+ statfs if available
         if (fs.statfsSync) {
-            const stats = fs.statfsSync(mount || '/');
+            const stats = fs.statfsSync(targetMount);
             const total = stats.blocks * stats.bsize;
             const free = stats.bavail * stats.bsize; // available to unprivileged users
             const used = total - free;
@@ -16,13 +23,7 @@ function getDiskUsage(mount) {
                 freeMb: Math.round(free / 1024 / 1024)
             };
         }
-        // Fallback
-        const safeMount = String(mount || '/').replace(/["';&|><`$()]/g, '');
-        const out = execSync(`df -P "${safeMount}" | tail -1 | awk '{print $5, $4}'`).toString().trim().split(' ');
-        return {
-            pct: parseInt(out[0].replace(/%/g, ''), 10),
-            freeMb: Math.round(parseInt(out[1], 10) / 1024) // df returns 1k blocks usually
-        };
+        return { pct: -1, freeMb: -1, error: 'statfs unavailable on this Node runtime' };
     } catch (e) {
         return { pct: -1, freeMb: -1, error: e.message };
     }
@@ -54,7 +55,7 @@ function runHealthCheck() {
     });
 
     // 2. Disk Space Check
-    const disk = getDiskUsage('/');
+    const disk = getDiskUsage(getDefaultMount());
     if (disk.error) {
         checks.push({ name: 'disk_space', ok: false, status: 'check failed: ' + disk.error, severity: 'warning' });
         warnings++;

--- a/src/ops/lifecycle.js
+++ b/src/ops/lifecycle.js
@@ -22,19 +22,53 @@ function getLoopScript() {
 
 // --- Process Discovery ---
 
+function sleepMs(ms) {
+    var delay = Math.max(0, Math.floor(Number(ms) || 0));
+    if (delay <= 0) return;
+    Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
+}
+
+function execText(command) {
+    return execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+}
+
+function listProcesses() {
+    if (process.platform === 'win32') {
+        var out = execText('powershell -NoProfile -Command "Get-CimInstance Win32_Process | ForEach-Object { $cmd = if ($_.CommandLine) { $_.CommandLine } else { \'\' }; Write-Output (\'{0}\\t{1}\' -f $_.ProcessId, $cmd) }"');
+        var procs = [];
+        for (var line of out.split(/\r?\n/)) {
+            if (!line || !line.trim()) continue;
+            var tabIndex = line.indexOf('\t');
+            var pidText = tabIndex >= 0 ? line.slice(0, tabIndex).trim() : line.trim();
+            var cmdText = tabIndex >= 0 ? line.slice(tabIndex + 1).trim() : '';
+            var pid = parseInt(pidText, 10);
+            if (!isNaN(pid)) procs.push({ pid: pid, args: cmdText });
+        }
+        return procs;
+    }
+    var psOut = execText('ps -e -o pid=,args=');
+    var unixProcs = [];
+    for (var psLine of psOut.split('\n')) {
+        var trimmed = psLine.trim();
+        if (!trimmed) continue;
+        var parts = trimmed.split(/\s+/);
+        var pidUnix = parseInt(parts[0], 10);
+        if (isNaN(pidUnix)) continue;
+        unixProcs.push({ pid: pidUnix, args: parts.slice(1).join(' ') });
+    }
+    return unixProcs;
+}
+
 function getRunningPids() {
     try {
-        var out = execSync('ps -e -o pid,args', { encoding: 'utf8' });
         var pids = [];
-        for (var line of out.split('\n')) {
-            var trimmed = line.trim();
-            if (!trimmed || trimmed.startsWith('PID')) continue;
-            var parts = trimmed.split(/\s+/);
-            var pid = parseInt(parts[0], 10);
-            var cmd = parts.slice(1).join(' ');
+        for (var proc of listProcesses()) {
+            var pid = proc.pid;
+            var cmd = (proc.args || '').trim();
             if (pid === process.pid) continue;
-            if (cmd.includes('node') && cmd.includes('index.js') && cmd.includes('--loop')) {
-                if (cmd.includes('feishu-evolver-wrapper') || cmd.includes('skills/evolver')) {
+            var cmdLower = cmd.toLowerCase();
+            if (cmdLower.includes('node') && cmdLower.includes('index.js') && cmdLower.includes('--loop')) {
+                if (cmdLower.includes('feishu-evolver-wrapper') || cmdLower.includes('skills/evolver')) {
                     pids.push(pid);
                 }
             }
@@ -53,7 +87,8 @@ function getCmdLine(pid) {
     try {
         const safePid = parseInt(pid, 10);
         if (isNaN(safePid)) return null;
-        return execSync(`ps -p ${safePid} -o args=`, { encoding: 'utf8' }).trim();
+        var proc = listProcesses().find(function(p) { return p.pid === safePid; });
+        return proc ? (proc.args || '').trim() : null;
     } catch (e) {
         return null;
     }
@@ -69,8 +104,7 @@ function start(options) {
         return { status: 'already_running', pids: pids };
     }
     if (delayMs > 0) {
-        const safeDelay = parseFloat(delayMs / 1000) || 0;
-        execSync(`sleep ${safeDelay}`);
+        sleepMs(delayMs);
     }
 
     var script = getLoopScript();
@@ -107,7 +141,7 @@ function stop() {
     }
     var attempts = 0;
     while (getRunningPids().length > 0 && attempts < 10) {
-        execSync('sleep 0.5');
+        sleepMs(500);
         attempts++;
     }
     var remaining = getRunningPids();
@@ -139,9 +173,33 @@ function tailLog(lines) {
     if (!fs.existsSync(LOG_FILE)) return { error: 'No log file' };
     try {
         const n = parseInt(lines, 10) || 20;
+        const fd = fs.openSync(LOG_FILE, 'r');
+        var content = '';
+        try {
+            const stat = fs.fstatSync(fd);
+            if (stat.size > 0) {
+                const chunkSize = 64 * 1024;
+                let position = stat.size;
+                let collected = '';
+                let lineCount = 0;
+                while (position > 0 && lineCount <= n) {
+                    const readSize = Math.min(chunkSize, position);
+                    position -= readSize;
+                    const buf = Buffer.alloc(readSize);
+                    fs.readSync(fd, buf, 0, readSize, position);
+                    collected = buf.toString('utf8') + collected;
+                    lineCount = collected.split('\n').length - 1;
+                }
+                const rows = collected.split('\n');
+                if (rows.length > 0 && rows[rows.length - 1] === '') rows.pop();
+                content = rows.slice(-n).join('\n');
+            }
+        } finally {
+            fs.closeSync(fd);
+        }
         return {
             file: path.relative(WORKSPACE_ROOT, LOG_FILE),
-            content: execSync(`tail -n ${n} "${LOG_FILE}"`, { encoding: 'utf8' })
+            content
         };
     } catch (e) {
         return { error: e.message };


### PR DESCRIPTION
## Summary

Replaces Unix-only `ps`, `sleep`, `tail`, and `df` shell-outs in `src/ops/lifecycle.js` and `src/ops/health_check.js` with portable Node primitives. No new npm dependencies.

## Why this matters

From #379 (@q7793527):

> `src/ops/lifecycle.js` is not Windows-compatible because it shells out to Unix commands like `ps`, `sleep`, and `tail`. This breaks lifecycle management on Windows in multiple ways: `status` reports `running: false` even when the loop process is alive, `check` can misclassify health because process discovery fails, `stop`/`restart` rely on Unix sleep calls, `log` relies on Unix tail.

Maintainer @autogame-17 confirmed in thread: "`lifecycle.js` currently uses Unix-only commands (`ps`, `sleep`, `tail`) which do not work on Windows." `src/ops/health_check.js` had the same class of bug in its `disk_space` check (`df -P | tail -1 | awk`).

## Changes

`src/ops/lifecycle.js`:

- `listProcesses()` helper: branches on `process.platform`. Unix keeps `ps -e -o pid=,args=`. Windows uses `powershell -NoProfile -Command "Get-CimInstance Win32_Process | ForEach-Object { ... }"` and parses `pid<TAB>commandline` output. Returns `[{pid, args}]`.
- `getRunningPids()` and `getCmdLine()` now call `listProcesses()` instead of shelling out directly.
- `sleepMs()` helper uses `Atomics.wait` on a `SharedArrayBuffer` for a portable synchronous sleep. Replaces `execSync('sleep N')` at the start delay and stop loop.
- `log()` now reads the log file via `fs.readSync` in 64KB chunks from EOF until it has N newlines, then returns the last N lines. Replaces `execSync('tail -n N FILE')`.

`src/ops/health_check.js`:

- `disk_space` check uses `fs.statfsSync()` (Node 18.15+) which returns `bsize`, `blocks`, `bavail`. Computes `used%` and free bytes in pure JS.
- `getDefaultMount()` picks `/` on Unix, the drive root of `process.cwd()` on Windows.
- Removed the `df`, `tail`, `awk` pipeline entirely.

## Testing

Verified on macOS:

- `node src/ops/lifecycle.js status` returns `{ "running": false }` as expected when no loop is active.
- `node -e "console.log(JSON.stringify(require('./src/ops/health_check').runHealthCheck(), null, 2))"` returns a clean payload including the disk_space check (`{ "name": "disk_space", "ok": true, "status": "27% used" }`).
- `grep -nE "execSync\\(['\\\`](ps|sleep|tail|df)" src/ops/*.js` returns no matches.

Windows path is inferred from Microsoft docs for `Get-CimInstance` and `fs.statfs`. Would appreciate a Windows verifier on the PR before merge. Happy to iterate if the PowerShell command needs adjustment for older Windows builds.

No emoji in code or commit message per CONTRIBUTING.md.

Fixes #379

This contribution was developed with AI assistance (Codex).
