### PR TITLE
fix(paths): agent sessions dir follows EVOLVER_SESSION_SCOPE (#371)

### DIFF
--- a/src/gep/paths.js
+++ b/src/gep/paths.js
@@ -98,6 +98,60 @@ function getSkillsDir() {
   return process.env.SKILLS_DIR || path.join(getWorkspaceRoot(), 'skills');
 }
 
+// Resolve the OpenClaw `sessions` directory for the agent that actually
+// matches the current EVOLVER_SESSION_SCOPE (fixes #371).
+//
+// Precedence:
+//   1. AGENT_SESSIONS_DIR         explicit override
+//   2. EVOLVER_SESSION_SCOPE with a `workspace-<agent>` prefix =>
+//      ~/.openclaw/agents/<agent>/sessions
+//   3. AGENT_NAME (defaults to "main")   pre-#371 behavior
+function getAgentSessionsDir() {
+  if (process.env.AGENT_SESSIONS_DIR) return process.env.AGENT_SESSIONS_DIR;
+
+  const scope = getSessionScope();
+  let agentName = null;
+  if (scope) {
+    const match = /^workspace-(.+)$/.exec(scope);
+    if (match) agentName = match[1];
+  }
+  if (!agentName) agentName = process.env.AGENT_NAME || 'main';
+
+  const home = process.env.HOME || process.env.USERPROFILE || '';
+  return path.join(home, '.openclaw', 'agents', agentName, 'sessions');
+}
+
+// Read the first `maxBytes` of a session .jsonl file and extract the `cwd`
+// field from its header record (fixes #371, bug 2).
+//
+// OpenClaw session files are newline-delimited JSON. The first record is a
+// session header that carries workspace context including `cwd`. The
+// pre-#371 matcher tailed the file, which never saw the header. This
+// reader is O(1) on file size. Returns null on any read/parse failure.
+function readSessionCwdFromHead(sessionFilePath, maxBytes) {
+  const cap = typeof maxBytes === 'number' && maxBytes > 0 ? maxBytes : 800;
+  try {
+    if (!fs.existsSync(sessionFilePath)) return null;
+    const fd = fs.openSync(sessionFilePath, 'r');
+    try {
+      const stat = fs.fstatSync(fd);
+      const readSize = Math.min(cap, stat.size);
+      if (readSize <= 0) return null;
+      const buf = Buffer.alloc(readSize);
+      fs.readSync(fd, buf, 0, readSize, 0);
+      const newline = buf.indexOf('\n');
+      const slice = newline >= 0 ? buf.slice(0, newline) : buf;
+      const record = JSON.parse(slice.toString('utf8'));
+      if (record && typeof record.cwd === 'string') return record.cwd;
+      return null;
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch (_err) {
+    return null;
+  }
+}
+
 function getNarrativePath() {
   return path.join(getEvolutionDir(), 'evolution_narrative.md');
 }
@@ -123,6 +177,8 @@ module.exports = {
   getGepAssetsDir,
   getSkillsDir,
   getSessionScope,
+  getAgentSessionsDir,
+  readSessionCwdFromHead,
   getNarrativePath,
   getEvolutionPrinciplesPath,
   getReflectionLogPath,

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -260,3 +260,113 @@ describe('getWorkspaceRoot', () => {
     assert.ok(getSkillsDir().startsWith(ws), 'skillsDir should be under workspaceRoot');
   });
 });
+
+describe('getAgentSessionsDir', () => {
+  const savedEnv = {};
+  const envKeys = ['AGENT_SESSIONS_DIR', 'AGENT_NAME', 'EVOLVER_SESSION_SCOPE', 'HOME'];
+
+  beforeEach(() => {
+    for (const k of envKeys) {
+      savedEnv[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const k of envKeys) {
+      if (savedEnv[k] === undefined) delete process.env[k];
+      else process.env[k] = savedEnv[k];
+    }
+  });
+
+  it('respects AGENT_SESSIONS_DIR override', () => {
+    process.env.AGENT_SESSIONS_DIR = '/tmp/override/sessions';
+    const { getAgentSessionsDir } = freshRequire('../src/gep/paths');
+    assert.equal(getAgentSessionsDir(), '/tmp/override/sessions');
+  });
+
+  it('derives agent name from workspace-<name> scope', () => {
+    process.env.HOME = '/tmp/home';
+    process.env.EVOLVER_SESSION_SCOPE = 'workspace-helperclaw';
+    const { getAgentSessionsDir } = freshRequire('../src/gep/paths');
+    assert.equal(
+      getAgentSessionsDir(),
+      path.join('/tmp/home', '.openclaw', 'agents', 'helperclaw', 'sessions'),
+    );
+  });
+
+  it('falls back to AGENT_NAME when scope has no workspace- prefix', () => {
+    process.env.HOME = '/tmp/home';
+    process.env.EVOLVER_SESSION_SCOPE = 'channel-123';
+    process.env.AGENT_NAME = 'custom-agent';
+    const { getAgentSessionsDir } = freshRequire('../src/gep/paths');
+    assert.equal(
+      getAgentSessionsDir(),
+      path.join('/tmp/home', '.openclaw', 'agents', 'custom-agent', 'sessions'),
+    );
+  });
+
+  it('defaults to main agent when neither scope nor AGENT_NAME is set', () => {
+    process.env.HOME = '/tmp/home';
+    const { getAgentSessionsDir } = freshRequire('../src/gep/paths');
+    assert.equal(
+      getAgentSessionsDir(),
+      path.join('/tmp/home', '.openclaw', 'agents', 'main', 'sessions'),
+    );
+  });
+});
+
+describe('readSessionCwdFromHead', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'session-head-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('extracts cwd from the first record', () => {
+    const file = path.join(tmpDir, 'session.jsonl');
+    const header = JSON.stringify({
+      type: 'session_start',
+      cwd: '/Users/test/workspaces/helperclaw',
+      id: 'c982d748',
+    });
+    const body = JSON.stringify({ type: 'user', text: 'hello' });
+    fs.writeFileSync(file, header + '\n' + body + '\n');
+    const { readSessionCwdFromHead } = freshRequire('../src/gep/paths');
+    assert.equal(readSessionCwdFromHead(file), '/Users/test/workspaces/helperclaw');
+  });
+
+  it('returns null when the header has no cwd field', () => {
+    const file = path.join(tmpDir, 'session.jsonl');
+    fs.writeFileSync(file, JSON.stringify({ type: 'session_start' }) + '\n');
+    const { readSessionCwdFromHead } = freshRequire('../src/gep/paths');
+    assert.equal(readSessionCwdFromHead(file), null);
+  });
+
+  it('returns null when the file does not exist', () => {
+    const { readSessionCwdFromHead } = freshRequire('../src/gep/paths');
+    assert.equal(readSessionCwdFromHead(path.join(tmpDir, 'missing.jsonl')), null);
+  });
+
+  it('returns null when the first line is not valid JSON', () => {
+    const file = path.join(tmpDir, 'session.jsonl');
+    fs.writeFileSync(file, 'not-json\n{"type":"user"}\n');
+    const { readSessionCwdFromHead } = freshRequire('../src/gep/paths');
+    assert.equal(readSessionCwdFromHead(file), null);
+  });
+
+  it('caps read size to the configured maxBytes', () => {
+    const file = path.join(tmpDir, 'session.jsonl');
+    const header = JSON.stringify({ type: 'session_start', cwd: '/ok', pad: 'x'.repeat(2048) });
+    fs.writeFileSync(file, header + '\n');
+    const { readSessionCwdFromHead } = freshRequire('../src/gep/paths');
+    // default 800-byte cap means the JSON slice won't parse; helper returns null
+    assert.equal(readSessionCwdFromHead(file), null);
+    // large enough cap recovers cwd
+    assert.equal(readSessionCwdFromHead(file, 4096), '/ok');
+  });
+});


### PR DESCRIPTION
## Summary

Adds two helpers to `src/gep/paths.js` addressing the two bugs on #371. The core session reader lives in the obfuscated `src/evolve.js` bundle, so this PR ships the helpers + tests; wiring the bundle to call them is a one-line change on the maintainer side.

## Why this matters

From #371 (@Bozhu12, confirmed by @autogame-17):

> Bug 1: `AGENT_SESSIONS_DIR` is derived from `AGENT_NAME` env var (defaults to "main"), not from `EVOLVER_SESSION_SCOPE`. Even when scope is set, the code reads from `~/.openclaw/agents/main/sessions` instead of `~/.openclaw/agents/helperclaw/sessions`.
>
> Bug 2: The scope matching logic uses `f.name.toLowerCase().includes(scopeLower)` - but session files are UUIDs which never contain the workspace scope string. Additionally, `readRecentLog()` reads from the tail of each file, but the session header (containing cwd) is at the head.

Maintainer confirmed in thread: "Both bugs are confirmed: 1. AGENT_SESSIONS_DIR should derive from EVOLVER_SESSION_SCOPE instead of always using AGENT_NAME. 2. Scope content matching reads the tail of session files..."

Reference implementation: https://github.com/Bozhu12/evolver/commit/db31a1f (v1.32.4 fork, by the issue author).

## Changes

`src/gep/paths.js`:

- `getAgentSessionsDir()` (new) - resolves the OpenClaw sessions directory with three-level precedence: `AGENT_SESSIONS_DIR` override, `EVOLVER_SESSION_SCOPE` with `workspace-<agent>` prefix, then `AGENT_NAME` (default "main"). Addresses bug 1.
- `readSessionCwdFromHead(file, maxBytes=800)` (new) - reads the first ~800 bytes of an OpenClaw session `.jsonl` and extracts `cwd` from the session header record. O(1) regardless of session length, returns `null` on any read/parse failure. Addresses bug 2.
- Both helpers exported from `module.exports` so the obfuscated bundle can import them when wiring up the fix.

`test/paths.test.js`:

- 9 new test cases covering override, scope-derived, `AGENT_NAME` fallback, default `main`, missing file, malformed JSON, and the `maxBytes` cap.
- All 32 tests in the file pass under `node --test`.

## Maintainer wiring note

The session reader that consumes these helpers lives in `src/evolve.js` (obfuscated). Two call-site changes are needed inside the bundle once this lands:

1. Replace the current `AGENT_SESSIONS_DIR` derivation with a call to `getAgentSessionsDir()`.
2. Replace the `tail`-based scope match with a call to `readSessionCwdFromHead(sessionFilePath)`, then match that cwd against `EVOLVER_SESSION_SCOPE` (or against a full `workspaces/<scope>` segment).

Happy to iterate on the helper shape if a different integration point works better for the bundle source.

## Testing

```
$ node --test test/paths.test.js
...
ℹ tests 32
ℹ pass 32
ℹ fail 0
```

No emoji in code or commit messages per CONTRIBUTING.md. No new npm dependencies.

Fixes #371

This contribution was developed with AI assistance (Claude Code).
