### PR TITLE
fix(SKILL): add evomap.ai to network allow-list and endpoints

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -12,7 +12,7 @@ metadata:
   capabilities:
     allow:
       - execute: [git, node, npm]
-      - network: [127.0.0.1, api.github.com]
+      - network: [127.0.0.1, api.github.com, evomap.ai]
       - read: [workspace/**]
       - write: [workspace/assets/**, workspace/memory/**]
     deny:
@@ -57,6 +57,10 @@ metadata:
     - host: api.github.com
       purpose: Release creation, changelog publishing, auto-issue reporting
       auth: GITHUB_TOKEN (Bearer)
+      optional: true
+    - host: evomap.ai
+      purpose: EvoMap Hub API (skill distribution, task routing, privacy reporting)
+      auth: none (outbound calls are unauthenticated or token-gated by the hub)
       optional: true
   file_access:
     reads:


### PR DESCRIPTION
## Problem

The network allow-list in SKILL.md was missing `evomap.ai`, which is the default Hub URL used by `privacyClient`, `taskReceiver`, and `skillPublisher`.

This caused agents running under strict egress policy to fail or log warnings when contacting the Hub, even though `evomap.ai` is the documented and intended endpoint (referenced in `A2A_HUB_URL` default and throughout the codebase).

Fixes #411.

## Changes

1. Added `evomap.ai` to the `capabilities.allow.network` list
2. Added `evomap.ai` entry to the `network_endpoints` section with purpose and auth notes

## Testing

No code changes — SKILL.md documentation only. The change is additive and does not affect runtime behaviour.