### PR TITLE
test(bridge): disable ANSI color in spawned child so stdout stays plain (#430)

### DIFF
--- a/test/bridge.test.js
+++ b/test/bridge.test.js
@@ -98,6 +98,13 @@ describe('determineBridgeEnabled -- black-box via child_process', () => {
     const cleanEnv = { ...process.env };
     delete cleanEnv.EVOLVE_BRIDGE;
     delete cleanEnv.OPENCLAW_WORKSPACE;
+    // Disable ANSI color in the child so stdout comparisons stay deterministic
+    // regardless of the parent shell's FORCE_COLOR setting. Without this, a
+    // parent that exported FORCE_COLOR=1 (common under some CI runners) can
+    // make the child print escape-coded booleans and the `.trim()` output
+    // becomes e.g. `\u001b[32mtrue\u001b[39m` instead of `true`.
+    cleanEnv.FORCE_COLOR = '0';
+    cleanEnv.NO_COLOR = '1';
     return execFileSync(process.execPath, ['-e', script], {
       cwd: require('path').resolve(__dirname, '..'),
       encoding: 'utf8',


### PR DESCRIPTION
## Summary

Tiny, test-only fix from the bridge-tests portion of #430. Makes the black-box `determineBridgeEnabled` test's child-process stdout deterministic regardless of the parent shell's ANSI color state.

## What changed

- `test/bridge.test.js` — explicitly set `FORCE_COLOR=0` and `NO_COLOR=1` on the `cleanEnv` passed to the spawned Node child. The test already strips `EVOLVE_BRIDGE` and `OPENCLAW_WORKSPACE`; this adds the same discipline for color env vars.

## How to test

```
node scripts/validate-suite.js
```

Expected: `ok: 871 test(s) passed, 0 failed` (13 tests in bridge.test.js among them).

## Risk

Low — the change is limited to the child's env in one black-box test helper. No production behavior touched, no integrity manifest touched, no `src/gep/*` file touched.

## Related

Partially addresses #430. The heartbeat and hub-events portions of that issue live inside the obfuscated `src/gep/a2aProtocol.js` module and, per @autogame-17's #429 close note, have to come from the official build pipeline rather than external PRs — this PR intentionally stays out of that scope.
