### PR TITLE
Fix getRepoRoot for global installs on different drives

### DIFF
--- a/src/gep/paths.js
+++ b/src/gep/paths.js
@@ -7,17 +7,20 @@ let _cachedRepoRoot = null;
 //
 // Precedence:
 //   1. EVOLVER_REPO_ROOT (explicit override, always wins)
-//   2. evolver's own directory if it has a .git
-//   3. Nearest ancestor directory that has a .git (the "host" workspace)
-//      - On by default since 1.69.6. This matches how most users install
-//        evolver (as an npm dependency or a skill under another repo):
-//        the Hand Agent writes files in the host workspace, not inside the
-//        evolver package, so git diff MUST run against the host repo.
-//      - To opt out (keep the 1.69.5 and earlier behavior of ignoring the
-//        parent git), set EVOLVER_NO_PARENT_GIT=true. The older
-//        EVOLVER_USE_PARENT_GIT=true flag is still honored for forward
-//        compatibility but is no longer required.
-//   4. Fall back to evolver's own directory.
+//   2. Nearest ancestor of process.cwd() that has a .git
+//      (user ran evolver from inside their project)
+//   3. Nearest ancestor of evolver's own directory that has a .git
+//      (local npm install: evolver is inside the project's node_modules)
+//   4. evolver's own directory if it has a .git (dev mode fallback)
+//   5. Fall back to evolver's own directory.
+//
+//   CWD is checked first because the user's intent is almost always to
+//   evolve the project they're standing in, not evolver itself.  evolver
+//   self-evolution happens naturally when CWD *is* the evolver repo.
+//
+//   To opt out, set EVOLVER_NO_PARENT_GIT=true.  The older
+//   EVOLVER_USE_PARENT_GIT=true flag is still honored for forward
+//   compatibility but is no longer required.
 function getRepoRoot() {
   if (_cachedRepoRoot) return _cachedRepoRoot;
 
@@ -28,38 +31,46 @@ function getRepoRoot() {
 
   const ownDir = path.resolve(__dirname, '..', '..');
 
-  if (fs.existsSync(path.join(ownDir, '.git'))) {
-    _cachedRepoRoot = ownDir;
-    return _cachedRepoRoot;
-  }
-
   const noParent = String(process.env.EVOLVER_NO_PARENT_GIT || '').toLowerCase() === 'true';
   // Older flag kept for backward compatibility. Setting it to 'false'
   // explicitly is treated as an opt-out, mirroring EVOLVER_NO_PARENT_GIT.
   const legacyFlag = process.env.EVOLVER_USE_PARENT_GIT;
   const legacyOptOut = typeof legacyFlag === 'string' && legacyFlag.toLowerCase() === 'false';
 
-  let dir = path.dirname(ownDir);
-  while (dir !== path.dirname(dir)) {
-    if (fs.existsSync(path.join(dir, '.git'))) {
-      if (noParent || legacyOptOut) {
+  // Walk upward from process.cwd() — the project the user is standing in.
+  if (!noParent && !legacyOptOut) {
+    let cwd = process.cwd();
+    while (cwd !== path.dirname(cwd)) {
+      if (fs.existsSync(path.join(cwd, '.git'))) {
         if (!process.env.EVOLVER_QUIET_PARENT_GIT) {
-          console.warn(
-            '[evolver] Detected .git in parent directory', dir,
-            '-- ignoring because EVOLVER_NO_PARENT_GIT is set.',
-            'Unset it (or set EVOLVER_REPO_ROOT) if evolution stalls with hollow_commit errors.'
-          );
+          console.log('[evolver] Using host git repository at:', cwd);
         }
-        _cachedRepoRoot = ownDir;
+        _cachedRepoRoot = cwd;
         return _cachedRepoRoot;
       }
-      if (!process.env.EVOLVER_QUIET_PARENT_GIT) {
-        console.log('[evolver] Using host git repository at:', dir);
-      }
-      _cachedRepoRoot = dir;
-      return _cachedRepoRoot;
+      cwd = path.dirname(cwd);
     }
-    dir = path.dirname(dir);
+  }
+
+  // Walk upward from ownDir's parent (local install inside node_modules).
+  if (!noParent && !legacyOptOut) {
+    let dir = path.dirname(ownDir);
+    while (dir !== path.dirname(dir)) {
+      if (fs.existsSync(path.join(dir, '.git'))) {
+        if (!process.env.EVOLVER_QUIET_PARENT_GIT) {
+          console.log('[evolver] Using host git repository at:', dir);
+        }
+        _cachedRepoRoot = dir;
+        return _cachedRepoRoot;
+      }
+      dir = path.dirname(dir);
+    }
+  }
+
+  // Fallback: evolver's own directory (dev mode or isolated install).
+  if (fs.existsSync(path.join(ownDir, '.git'))) {
+    _cachedRepoRoot = ownDir;
+    return _cachedRepoRoot;
   }
 
   _cachedRepoRoot = ownDir;

--- a/test/paths.test.js
+++ b/test/paths.test.js
@@ -42,14 +42,52 @@ describe('getRepoRoot', () => {
     assert.equal(getRepoRoot(), tmpDir);
   });
 
-  it('returns own directory when it has .git', () => {
+  // When CWD is inside the evolver repo itself (e.g. running tests),
+  // the CWD walk finds the same .git as ownDir — both resolve to the
+  // evolver repo.
+  it('returns own directory when CWD is inside the evolver repo', () => {
     const ownDir = path.resolve(__dirname, '..');
     const { getRepoRoot } = freshRequire('../src/gep/paths');
     delete process.env.EVOLVER_REPO_ROOT;
     const result = getRepoRoot();
     assert.ok(typeof result === 'string' && result.length > 0);
-    // evolver repo itself is a git repo during test, so we stop at ownDir
     assert.equal(result, ownDir);
+  });
+
+  // CWD git repo takes precedence over evolver's own .git (the fix for
+  // global installs where evolver happens to have .git but the user ran
+  // it from a different project).
+  it('prefers CWD git repo over evolver own .git', () => {
+    // Simulate a global install that has .git (e.g. npm install from git).
+    const globalDir = fs.mkdtempSync(path.join(os.tmpdir(), 'global-pkg-'));
+    fs.mkdirSync(path.join(globalDir, '.git'));
+    const fakeGepDir = path.join(globalDir, 'src', 'gep');
+    fs.mkdirSync(fakeGepDir, { recursive: true });
+    const pathsSrc = fs.readFileSync(
+      path.resolve(__dirname, '..', 'src', 'gep', 'paths.js'),
+      'utf8'
+    );
+    fs.writeFileSync(path.join(fakeGepDir, 'paths.js'), pathsSrc);
+
+    // Create a separate user project with .git.
+    const projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-'));
+    fs.mkdirSync(path.join(projectDir, '.git'));
+
+    const resolved = require.resolve(path.join(fakeGepDir, 'paths.js'));
+    delete require.cache[resolved];
+    const mod = require(resolved);
+
+    const origCwd = process.cwd;
+    process.cwd = () => projectDir;
+    try {
+      // CWD project should win over evolver's own .git.
+      assert.equal(mod.getRepoRoot(), projectDir);
+    } finally {
+      process.cwd = origCwd;
+      delete require.cache[resolved];
+      fs.rmSync(globalDir, { recursive: true, force: true });
+      fs.rmSync(projectDir, { recursive: true, force: true });
+    }
   });
 
   it('EVOLVER_REPO_ROOT takes precedence over .git detection', () => {
@@ -78,11 +116,19 @@ describe('getRepoRoot', () => {
 
     const resolved = require.resolve(path.join(fakeGepDir, 'paths.js'));
     delete require.cache[resolved];
-    const { getRepoRoot } = require(resolved);
-    assert.equal(getRepoRoot(), host);
+    const mod = require(resolved);
 
-    delete require.cache[resolved];
-    fs.rmSync(host, { recursive: true, force: true });
+    // The CWD walk must also point inside the host tree so it doesn't
+    // find the real evolver repo on disk before the ownDir walk runs.
+    const origCwd = process.cwd;
+    process.cwd = () => path.join(host, 'node_modules', '@evomap', 'evolver');
+    try {
+      assert.equal(mod.getRepoRoot(), host);
+    } finally {
+      process.cwd = origCwd;
+      delete require.cache[resolved];
+      fs.rmSync(host, { recursive: true, force: true });
+    }
   });
 
   it('respects EVOLVER_NO_PARENT_GIT=true as opt-out', () => {


### PR DESCRIPTION
## Summary

Fixes #461

- Add `process.cwd()` ancestor walk as the primary `.git` detection mechanism (after `EVOLVER_REPO_ROOT` env override), so evolver correctly finds the user's project when installed globally on a different drive
- Demote `ownDir` ancestor walk to secondary — still covers local npm installs where evolver lives inside `node_modules`
- Demote `ownDir/.git` to fallback — evolver self-evolution happens naturally when CWD *is* the evolver repo
- Opt-out flags (`EVOLVER_NO_PARENT_GIT`, `EVOLVER_USE_PARENT_GIT=false`) apply to both CWD and ownDir walks

## Test plan

- [x] All 36 existing tests pass, including v1.69.6 regression guards
- [x] New test: "prefers CWD git repo over evolver own .git" verifies that even when evolver itself has `.git`, the CWD project wins
- [x] Updated test: "auto-detects parent .git when own directory has none" now isolates CWD to the host tree so it doesn't accidentally find the real evolver repo
- [ ] Manual: `npm install -g` from this branch, then run `evolver` from a project on a different drive

🤖 Generated with [Claude Code](https://claude.com/claude-code)