### PR TITLE
fix: add error logging to silent catch blocks in selfPR.js

### DIFF
--- a/src/gep/selfPR.js
+++ b/src/gep/selfPR.js
@@ -102,7 +102,7 @@ function writeState(state) {
     const dir = getEvolutionDir();
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
     fs.writeFileSync(getStatePath(), JSON.stringify(state, null, 2) + '\n');
-  } catch (_) {}
+  } catch (e) { console.warn('[SelfPR] Failed to save state:', e.message); }
 }
 
 function isInCooldown() {
@@ -225,7 +225,7 @@ function getGitDiff(changedFiles, repoRoot) {
         { cwd: repoRoot, timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_EXEC_BUFFER }
       );
       if (result && result.trim()) parts.push(result.trim());
-    } catch (_) {}
+    } catch (e) { console.warn('[SelfPR] Summary method failed:', e.message); }
     if (parts.length === before) {
       try {
         const result = execSync(
@@ -233,7 +233,7 @@ function getGitDiff(changedFiles, repoRoot) {
           { cwd: repoRoot, timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_EXEC_BUFFER }
         );
         if (result && result.trim()) parts.push(result.trim());
-      } catch (_) {}
+      } catch (e) { console.warn('[SelfPR] Fallback summary failed:', e.message); }
     }
   }
   return parts.join('\n');


### PR DESCRIPTION
## Problem

Several `catch (_) {}` blocks in `src/gep/selfPR.js` silently swallow errors that can cause PR creation to fail with no diagnostic output. When `selfPR` fails to write state or generate a summary, users see no indication of what went wrong.

## Changes

Added `console.warn` logging to 3 catch blocks where errors are genuinely hidden:

| Location | Before | After |
|----------|--------|-------|
| State file write (L105) | `catch (_) {}` | `catch (e) { console.warn(...) }` |
| Summary generation (L228) | `catch (_) {}` | `catch (e) { console.warn(...) }` |
| Fallback summary (L236) | `catch (_) {}` | `catch (e) { console.warn(...) }` |

Kept 3 intentionally silent catches unchanged:
- Optional state file read → returns default
- Individual file read in diff loop → skips file
- Temp directory cleanup → best-effort

## Context

Found via automated code scanning (132 empty catch blocks across the codebase). This PR addresses the highest-impact file first — `selfPR.js` is responsible for creating PRs, so silent failures here directly block the evolution loop.