### PR TITLE
fix: add debug logging to silent catch blocks in core GEP modules

### DIFF
--- a/src/gep/a2a.js
+++ b/src/gep/a2a.js
@@ -56,7 +56,7 @@ function lowerConfidence(asset, opts) {
   cloned.a2a.received_at = receivedAt;
   cloned.a2a.confidence_factor = factor;
   if (!cloned.schema_version) cloned.schema_version = SCHEMA_VERSION;
-  if (!cloned.asset_id) { try { cloned.asset_id = computeAssetId(cloned); } catch (e) {} }
+  if (!cloned.asset_id) { try { cloned.asset_id = computeAssetId(cloned); } catch (e) { if (process.env.DEBUG) process.stderr.write('a2a: computeAssetId failed: ' + e.message + '\n'); } }
   return cloned;
 }
 
@@ -107,7 +107,7 @@ function exportEligibleCapsules(params) {
   for (var i = 0; i < eligible.length; i++) {
     var c = eligible[i];
     if (!c.schema_version) c.schema_version = SCHEMA_VERSION;
-    if (!c.asset_id) { try { c.asset_id = computeAssetId(c); } catch (e) {} }
+    if (!c.asset_id) { try { c.asset_id = computeAssetId(c); } catch (e) { if (process.env.DEBUG) process.stderr.write('a2a: computeAssetId failed for capsule: ' + e.message + '\n'); } }
   }
   return eligible;
 }
@@ -127,7 +127,7 @@ function exportEligibleGenes(params) {
   for (var i = 0; i < eligible.length; i++) {
     var g = eligible[i];
     if (!g.schema_version) g.schema_version = SCHEMA_VERSION;
-    if (!g.asset_id) { try { g.asset_id = computeAssetId(g); } catch (e) {} }
+    if (!g.asset_id) { try { g.asset_id = computeAssetId(g); } catch (e) { if (process.env.DEBUG) process.stderr.write('a2a: computeAssetId failed for gene: ' + e.message + '\n'); } }
   }
   return eligible;
 }

--- a/src/gep/assetStore.js
+++ b/src/gep/assetStore.js
@@ -186,7 +186,7 @@ function loadGenes() {
           try {
             const parsed = JSON.parse(line);
             if (parsed && parsed.type === 'Gene') jsonlGenes.push(parsed);
-          } catch(e) {}
+          } catch(e) { if (process.env.DEBUG) process.stderr.write("assetStore: malformed JSONL line: " + e.message + "\n"); }
         }
       });
     }
@@ -212,7 +212,7 @@ function loadCapsules() {
       const raw = fs.readFileSync(p, 'utf8');
       raw.split('\n').forEach(line => {
         if (line.trim()) {
-            try { jsonlCapsules.push(JSON.parse(line)); } catch(e) {}
+            try { jsonlCapsules.push(JSON.parse(line)); } catch(e) { if (process.env.DEBUG) process.stderr.write("assetStore: malformed JSONL line: " + e.message + "\n"); }
         }
       });
     }


### PR DESCRIPTION
## Summary

Add debug-gated error logging to silent `catch` blocks in `src/gep/a2a.js` and `src/gep/assetStore.js`.

## Problem

Several empty catch blocks silently swallow errors that could indicate real issues:

- **assetStore.js**: Malformed JSONL lines in gene/capsule stores are silently discarded. If an asset file gets corrupted, there is no way to diagnose the issue — the loader simply skips broken entries without any trace.
- **a2a.js**: `computeAssetId()` failures are silently ignored, meaning assets can end up without an `asset_id`. This breaks deduplication, lineage tracking, and any downstream logic that relies on stable identity.

## Solution

All logging is gated behind `process.env.DEBUG` to preserve current behavior in production while enabling observability during development:

```js
// Before
} catch (e) {}

// After  
} catch (e) { if (process.env.DEBUG) process.stderr.write("context: " + e.message + "\n"); }
```

**Zero behavior change** for existing users. Only visible when `DEBUG=1` is set.

## How found

Automated code quality scan flagged 132 empty catch blocks across the codebase. This PR addresses the ones in core GEP logic where silent failures could mask data integrity issues. Cleanup ops (`fs.rmSync`, `fs.unlinkSync`) and format-probing patterns were intentionally left unchanged.