### PR TITLE
fix(mailbox): ignore duplicate inbound message ids

### DIFF
--- a/src/proxy/mailbox/store.js
+++ b/src/proxy/mailbox/store.js
@@ -210,6 +210,8 @@ class MailboxStore {
 
   writeInbound({ id, type, payload, channel, priority, refId, expiresAt }) {
     const msgId = id || generateUUIDv7();
+    if (this._messages.has(msgId)) return msgId;
+
     const now = Date.now();
     const msg = {
       id: msgId,

--- a/test/mailboxStore.test.js
+++ b/test/mailboxStore.test.js
@@ -99,6 +99,19 @@ describe('MailboxStore', () => {
       const id = store.writeInbound({ id: customId, type: 'hub_event', payload: {} });
       assert.equal(id, customId);
     });
+
+    it('ignores duplicate inbound ids', () => {
+      const store2 = new MailboxStore(tmpDataDir());
+      const customId = generateUUIDv7();
+
+      store2.writeInbound({ id: customId, type: 'hub_event', payload: { n: 1 } });
+      const duplicateId = store2.writeInbound({ id: customId, type: 'hub_event', payload: { n: 2 } });
+
+      assert.equal(duplicateId, customId);
+      assert.equal(store2.countPending({ direction: 'inbound' }), 1);
+      assert.deepEqual(store2.poll({ type: 'hub_event' }).map(m => m.payload), [{ n: 1 }]);
+      store2.close();
+    });
   });
 
   describe('writeInboundBatch()', () => {


### PR DESCRIPTION
## Summary

- Make inbound mailbox writes idempotent when the same message id is received more than once.
- Keep the first stored inbound message and avoid appending duplicate entries to the pending inbound index.
- Add a regression test covering duplicate inbound ids.

## Root cause

`writeInbound()` always appended the message id to `_inbound`, even when `_messages` already contained that id. A retried Hub delivery could therefore make `poll()` and `countPending()` report the same message more than once.

## Testing

- `node --test test/mailboxStore.test.js`