### PR TITLE
fix(lifecycle): compare prerelease proxy versions correctly

### DIFF
--- a/src/proxy/lifecycle/manager.js
+++ b/src/proxy/lifecycle/manager.js
@@ -302,7 +302,7 @@ class LifecycleManager {
   }
 
   _shouldUpgrade(minVersion) {
-    const parse = (v) => String(v || '0.0.0').split('.').map(Number);
+    const parse = (v) => String(v || '0.0.0').split('.').map(part => parseInt(part, 10));
     const min = parse(minVersion);
     const cur = parse(PROXY_PROTOCOL_VERSION);
     for (let i = 0; i < 3; i++) {

--- a/test/lifecycleRateLimit.test.js
+++ b/test/lifecycleRateLimit.test.js
@@ -121,3 +121,11 @@ test('lifecycle reAuthenticate: breaks on hello_rate_limited without retrying', 
     global.fetch = originalFetch;
   }
 });
+
+test('lifecycle _shouldUpgrade: handles prerelease minimum versions', () => {
+  const mgr = new LifecycleManager({ hubUrl: 'https://example.test', store: makeStore(), logger: silentLogger() });
+
+  assert.strictEqual(mgr._shouldUpgrade('0.1.0-beta.1'), false);
+  assert.strictEqual(mgr._shouldUpgrade('0.1.1-beta.1'), true);
+  assert.strictEqual(mgr._shouldUpgrade('0.2.0-beta.1'), true);
+});


### PR DESCRIPTION
## Summary

- Compare only numeric major/minor/patch components in the proxy minimum-version gate.
- Handle prerelease minimum versions such as `0.1.1-beta.1` correctly.
- Add coverage for prerelease upgrade comparisons.

## Root cause

`_shouldUpgrade()` used `Number()` on each dot-separated version segment. For prerelease patch segments like `1-beta`, `Number()` returns `NaN`, which was later treated like `0` in the comparison.

## Testing

- `node --test test/lifecycleRateLimit.test.js`