### PR TITLE
update(security): harden proxy auth, validator sandbox, update paths, and command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ Requires `GITHUB_TOKEN` (or `GH_TOKEN` / `GITHUB_PAT`) with `repo` scope. When n
 
 This section describes the execution boundaries and trust model of the Evolver.
 
+Operational guidance for safer deployment lives in [SECURITY.md](SECURITY.md).
+
 ### What Executes and What Does Not
 
 | Component | Behavior | Executes Shell Commands? |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Notes
+
+This document describes the current security posture of the readable parts of this repository and the operating assumptions required for safer deployment.
+
+## Current Hardening
+
+Recent security hardening in this branch includes:
+
+- local proxy authentication via per-install token
+- stricter permissions for proxy settings and mailbox state files
+- validator sandbox path restrictions
+- signed skill update enforcement by default
+- `force update` disabled unless explicitly enabled
+- `skills_monitor` auto-install disabled unless explicitly enabled
+- argv-based git/process execution in several modules to reduce shell injection risk
+
+## Deployment Guidance
+
+Treat Evolver as a privileged local automation tool.
+
+Recommended baseline:
+
+1. Run it on a dedicated user account.
+2. Keep it off shared or multi-tenant hosts.
+3. Prefer offline mode unless Hub features are required.
+4. If validator mode is enabled, run it inside a container or VM with network egress controls.
+5. Do not enable `EVOLVE_GIT_RESET`, `EVOLVER_ENABLE_FORCE_UPDATE`, or `EVOLVER_ENABLE_SKILL_AUTO_INSTALL` unless you have a clear operational reason.
+
+## Sensitive Flags
+
+These flags materially increase risk and should stay off by default:
+
+- `EVOLVE_GIT_RESET=true`
+- `EVOLVER_ENABLE_FORCE_UPDATE=true`
+- `EVOLVER_ENABLE_SKILL_AUTO_INSTALL=true`
+- `EVOMAP_ALLOW_UNSIGNED_SKILL_UPDATE=true`
+- `EVOMAP_PROXY_REQUIRE_AUTH=false`
+
+## Remaining High-Risk Areas
+
+The following areas still deserve deeper audit:
+
+- validator execution isolation beyond path validation
+- Hub trust model and message authenticity
+- any path that can update local skills or fetch remote assets
+- destructive recovery paths guarded by environment variables
+
+## Recommended Next Steps
+
+1. Add container-based validator isolation guidance and example configs.
+2. Add signature verification for remote updates beyond skill payload hash checks.
+3. Add more tests around proxy auth failures and recovery flows.
+4. Add a public security reporting process and maintainer contact.

--- a/src/adapters/scripts/evolver-session-end.js
+++ b/src/adapters/scripts/evolver-session-end.js
@@ -6,7 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync, spawnSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -52,16 +52,38 @@ function findMemoryGraph(evolverRoot) {
 function getGitDiffStats() {
   try {
     const cwd = process.cwd();
-    const stat = execSync('git diff --stat HEAD~1 2>/dev/null || git diff --stat 2>/dev/null || echo ""', {
-      cwd,
-      encoding: 'utf8',
-      timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
-    }).trim();
-    const diffContent = execSync('git diff HEAD~1 --no-color 2>/dev/null || git diff --no-color 2>/dev/null || echo ""', {
-      cwd,
-      encoding: 'utf8',
-      timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
-    }).trim();
+    let stat = '';
+    let diffContent = '';
+    try {
+      stat = execFileSync('git', ['diff', '--stat', 'HEAD~1'], {
+        cwd,
+        encoding: 'utf8',
+        timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+      }).trim();
+    } catch (_) {
+      try {
+        stat = execFileSync('git', ['diff', '--stat'], {
+          cwd,
+          encoding: 'utf8',
+          timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+        }).trim();
+      } catch (_) {}
+    }
+    try {
+      diffContent = execFileSync('git', ['diff', 'HEAD~1', '--no-color'], {
+        cwd,
+        encoding: 'utf8',
+        timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+      }).trim();
+    } catch (_) {
+      try {
+        diffContent = execFileSync('git', ['diff', '--no-color'], {
+          cwd,
+          encoding: 'utf8',
+          timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+        }).trim();
+      } catch (_) {}
+    }
     const filesChanged = (stat.match(/\d+ files? changed/) || ['0'])[0];
     const insertions = (stat.match(/(\d+) insertions?/) || [null, '0'])[1];
     const deletions = (stat.match(/(\d+) deletions?/) || [null, '0'])[1];

--- a/src/atp/hubClient.js
+++ b/src/atp/hubClient.js
@@ -16,7 +16,7 @@
 
 const http = require('http');
 const { getHubUrl, buildHubHeaders, getNodeId } = require('../gep/a2aProtocol');
-const { getProxyUrl } = require('../proxy/server/settings');
+const { getProxyUrl, getProxyRequestHeaders } = require('../proxy/server/settings');
 
 function _isProxyMode() {
   if (process.env.EVOMAP_PROXY === '1') return true;
@@ -33,7 +33,7 @@ function _proxyRequest(method, path, body, timeoutMs) {
 
   return new Promise(function (resolve) {
     const payload = body ? JSON.stringify(body) : '';
-    const headers = { 'Content-Type': 'application/json' };
+    const headers = Object.assign({ 'Content-Type': 'application/json' }, getProxyRequestHeaders());
     if (payload) headers['Content-Length'] = Buffer.byteLength(payload);
 
     const req = http.request(

--- a/src/forceUpdate.js
+++ b/src/forceUpdate.js
@@ -4,6 +4,7 @@ const { execSync } = require('child_process');
 const { getRepoRoot } = require('./gep/paths');
 
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
+const FORCE_UPDATE_ENABLED = String(process.env.EVOLVER_ENABLE_FORCE_UPDATE || '').toLowerCase() === 'true';
 
 // Force Update: triggered by Hub when version is critically outdated.
 // Extracted from src/evolve.js so both the evolve main loop and heartbeat
@@ -14,6 +15,14 @@ function executeForceUpdate(forceUpdate) {
   const REPO_ROOT = getRepoRoot();
   const requiredVersion = String(forceUpdate.required_version || '').replace(/^>=/, '');
   console.log('[ForceUpdate] Starting multi-channel update (target: >=' + requiredVersion + ')');
+
+  if (!FORCE_UPDATE_ENABLED) {
+    console.warn('[ForceUpdate] Automatic force update is disabled. Set EVOLVER_ENABLE_FORCE_UPDATE=true to opt in.');
+    if (forceUpdate && forceUpdate.release_url) {
+      console.warn('[ForceUpdate] Manual update URL: ' + forceUpdate.release_url);
+    }
+    return false;
+  }
 
   function parseVer(v) {
     var m = String(v || '').match(/(\d+)\.(\d+)\.(\d+)/);

--- a/src/gep/gitOps.js
+++ b/src/gep/gitOps.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { getRepoRoot } = require('./paths');
 
 // 10 MB — prevents RangeError: stdout maxBuffer length exceeded on large
@@ -11,15 +11,23 @@ const { getRepoRoot } = require('./paths');
 // on repos with large refactors (see GHSA reports / issue #451).
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
 
-function runCmd(cmd, opts = {}) {
+function runCmd(args, opts = {}) {
+  const argv = Array.isArray(args) ? args : [];
   const cwd = opts.cwd || getRepoRoot();
   const timeoutMs = Number.isFinite(Number(opts.timeoutMs)) ? Number(opts.timeoutMs) : 120000;
-  return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: timeoutMs, maxBuffer: MAX_EXEC_BUFFER, windowsHide: true });
+  return execFileSync('git', argv, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: timeoutMs,
+    maxBuffer: MAX_EXEC_BUFFER,
+    windowsHide: true,
+  });
 }
 
-function tryRunCmd(cmd, opts = {}) {
+function tryRunCmd(args, opts = {}) {
   try {
-    return { ok: true, out: runCmd(cmd, opts), err: '' };
+    return { ok: true, out: runCmd(args, opts), err: '' };
   } catch (e) {
     const stderr = e && e.stderr ? String(e.stderr) : '';
     const stdout = e && e.stdout ? String(e.stdout) : '';
@@ -47,17 +55,17 @@ function countFileLines(absPath) {
 
 function gitListChangedFiles({ repoRoot }) {
   const files = new Set();
-  const s1 = tryRunCmd('git diff --name-only', { cwd: repoRoot, timeoutMs: 60000 });
+  const s1 = tryRunCmd(['diff', '--name-only'], { cwd: repoRoot, timeoutMs: 60000 });
   if (s1.ok) for (const line of String(s1.out).split('\n').map(l => l.trim()).filter(Boolean)) files.add(line);
-  const s2 = tryRunCmd('git diff --cached --name-only', { cwd: repoRoot, timeoutMs: 60000 });
+  const s2 = tryRunCmd(['diff', '--cached', '--name-only'], { cwd: repoRoot, timeoutMs: 60000 });
   if (s2.ok) for (const line of String(s2.out).split('\n').map(l => l.trim()).filter(Boolean)) files.add(line);
-  const s3 = tryRunCmd('git ls-files --others --exclude-standard', { cwd: repoRoot, timeoutMs: 60000 });
+  const s3 = tryRunCmd(['ls-files', '--others', '--exclude-standard'], { cwd: repoRoot, timeoutMs: 60000 });
   if (s3.ok) for (const line of String(s3.out).split('\n').map(l => l.trim()).filter(Boolean)) files.add(line);
   return Array.from(files);
 }
 
 function gitListUntrackedFiles(repoRoot) {
-  const r = tryRunCmd('git ls-files --others --exclude-standard', { cwd: repoRoot, timeoutMs: 60000 });
+  const r = tryRunCmd(['ls-files', '--others', '--exclude-standard'], { cwd: repoRoot, timeoutMs: 60000 });
   if (!r.ok) return [];
   return String(r.out).split('\n').map(l => l.trim()).filter(Boolean);
 }
@@ -66,9 +74,9 @@ const DIFF_SNAPSHOT_MAX_CHARS = 8000;
 
 function captureDiffSnapshot(repoRoot) {
   const parts = [];
-  const unstaged = tryRunCmd('git diff', { cwd: repoRoot, timeoutMs: 30000 });
+  const unstaged = tryRunCmd(['diff'], { cwd: repoRoot, timeoutMs: 30000 });
   if (unstaged.ok && unstaged.out) parts.push(String(unstaged.out));
-  const staged = tryRunCmd('git diff --cached', { cwd: repoRoot, timeoutMs: 30000 });
+  const staged = tryRunCmd(['diff', '--cached'], { cwd: repoRoot, timeoutMs: 30000 });
   if (staged.ok && staged.out) parts.push(String(staged.out));
   let combined = parts.join('\n');
   if (combined.length > DIFF_SNAPSHOT_MAX_CHARS) {
@@ -79,9 +87,10 @@ function captureDiffSnapshot(repoRoot) {
 
 function isGitRepo(dir) {
   try {
-    execSync('git rev-parse --git-dir', {
+    execFileSync('git', ['rev-parse', '--git-dir'], {
       cwd: dir, encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000, maxBuffer: MAX_EXEC_BUFFER,
+      windowsHide: true,
     });
     return true;
   } catch (_) {
@@ -139,20 +148,20 @@ function rollbackTracked(repoRoot) {
 
   if (mode === 'stash') {
     const stashRef = 'evolver-rollback-' + Date.now();
-    const result = tryRunCmd('git stash push -m "' + stashRef + '" --include-untracked', { cwd: repoRoot, timeoutMs: 60000 });
+    const result = tryRunCmd(['stash', 'push', '-m', stashRef, '--include-untracked'], { cwd: repoRoot, timeoutMs: 60000 });
     if (result.ok) {
       console.log('[Rollback] Changes stashed with ref: ' + stashRef + '. Recover with "git stash list" and "git stash pop".');
     } else {
       console.log('[Rollback] Stash failed or no changes, using hard reset');
-      tryRunCmd('git restore --staged --worktree .', { cwd: repoRoot, timeoutMs: 60000 });
-      tryRunCmd('git reset --hard', { cwd: repoRoot, timeoutMs: 60000 });
+      tryRunCmd(['restore', '--staged', '--worktree', '.'], { cwd: repoRoot, timeoutMs: 60000 });
+      tryRunCmd(['reset', '--hard'], { cwd: repoRoot, timeoutMs: 60000 });
     }
     return;
   }
 
   console.log('[Rollback] EVOLVER_ROLLBACK_MODE=hard, resetting tracked files in: ' + repoRoot);
-  tryRunCmd('git restore --staged --worktree .', { cwd: repoRoot, timeoutMs: 60000 });
-  tryRunCmd('git reset --hard', { cwd: repoRoot, timeoutMs: 60000 });
+  tryRunCmd(['restore', '--staged', '--worktree', '.'], { cwd: repoRoot, timeoutMs: 60000 });
+  tryRunCmd(['reset', '--hard'], { cwd: repoRoot, timeoutMs: 60000 });
 }
 
 function rollbackNewUntrackedFiles({ repoRoot, baselineUntracked }) {

--- a/src/gep/idleScheduler.js
+++ b/src/gep/idleScheduler.js
@@ -5,7 +5,7 @@
 // When idle, the evolver can run more aggressive operations (distillation,
 // reflection); when busy, it only collects signals.
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -40,19 +40,19 @@ function getSystemIdleSeconds() {
       ].join('\n');
       const tmpPs = path.join(require('os').tmpdir(), 'evolver_idle_check.ps1');
       require('fs').writeFileSync(tmpPs, psCode, 'utf8');
-      const result = execSync('powershell -NoProfile -ExecutionPolicy Bypass -File "' + tmpPs + '"', { timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
+      const result = execFileSync('powershell', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', tmpPs], { timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
       try { require('fs').unlinkSync(tmpPs); } catch (e) {}
       const seconds = parseInt(result, 10);
       return Number.isFinite(seconds) ? seconds : -1;
     } else if (platform === 'darwin') {
-      const result = execSync('ioreg -c IOHIDSystem | grep HIDIdleTime', { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
+      const result = execFileSync('ioreg', ['-c', 'IOHIDSystem'], { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
       const match = result.match(/(\d+)/);
       if (match) {
         return Math.floor(parseInt(match[1], 10) / 1000000000);
       }
     } else if (platform === 'linux') {
       try {
-        const result = execSync('xprintidle 2>/dev/null || echo -1', { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
+        const result = execFileSync('xprintidle', [], { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
         const ms = parseInt(result, 10);
         if (Number.isFinite(ms) && ms >= 0) return Math.floor(ms / 1000);
       } catch (e) {}

--- a/src/gep/mailboxTransport.js
+++ b/src/gep/mailboxTransport.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const http = require('http');
-const { getProxyUrl } = require('../proxy/server/settings');
+const { getProxyUrl, getProxyRequestHeaders } = require('../proxy/server/settings');
 
 function _request(method, path, body) {
   const proxyUrl = getProxyUrl();
@@ -13,16 +13,17 @@ function _request(method, path, body) {
 
   return new Promise((resolve, reject) => {
     const payload = body ? JSON.stringify(body) : '';
+    const headers = Object.assign({
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload),
+    }, getProxyRequestHeaders());
     const req = http.request(
       {
         hostname: url.hostname,
         port: url.port,
         path: url.pathname,
         method,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(payload),
-        },
+        headers,
         timeout: 10_000,
       },
       (res) => {

--- a/src/gep/mailboxTransport.js
+++ b/src/gep/mailboxTransport.js
@@ -21,7 +21,7 @@ function _request(method, path, body) {
       {
         hostname: url.hostname,
         port: url.port,
-        path: url.pathname,
+        path: url.pathname + (url.search || ''),
         method,
         headers,
         timeout: 10_000,

--- a/src/gep/selfPR.js
+++ b/src/gep/selfPR.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -206,7 +206,8 @@ function runGh(args, opts) {
   const timeoutMs = (opts && opts.timeoutMs) || SELF_PR_TIMEOUT_MS;
   const cwd = (opts && opts.cwd) || getRepoRoot();
   try {
-    const result = execSync('gh ' + args, {
+    const argv = Array.isArray(args) ? args : String(args || '').split(/\s+/).filter(Boolean);
+    const result = execFileSync('gh', argv, {
       cwd: cwd,
       timeout: timeoutMs,
       encoding: 'utf8',
@@ -224,16 +225,18 @@ function getGitDiff(changedFiles, repoRoot) {
   for (const f of changedFiles) {
     const before = parts.length;
     try {
-      const result = execSync(
-        'git diff HEAD -- "' + f + '"',
+      const result = execFileSync(
+        'git',
+        ['diff', 'HEAD', '--', f],
         { cwd: repoRoot, timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_EXEC_BUFFER }
       );
       if (result && result.trim()) parts.push(result.trim());
     } catch (_) {}
     if (parts.length === before) {
       try {
-        const result = execSync(
-          'git diff -- "' + f + '"',
+        const result = execFileSync(
+          'git',
+          ['diff', '--', f],
           { cwd: repoRoot, timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_EXEC_BUFFER }
         );
         if (result && result.trim()) parts.push(result.trim());
@@ -300,7 +303,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
   try {
     console.log('[SelfPR] Creating PR on ' + repo + ' branch ' + branch + '...');
 
-    const forkCheck = runGh('repo view ' + repo + ' --json name', { timeoutMs: 15000 });
+    const forkCheck = runGh(['repo', 'view', repo, '--json', 'name'], { timeoutMs: 15000 });
     if (!forkCheck.ok) {
       console.warn('[SelfPR] Cannot access repo ' + repo + ': ' + (forkCheck.err || 'unknown'));
       return { attempted: false, reason: 'repo_access_failed' };
@@ -313,7 +316,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     fs.mkdirSync(tmpDir, { recursive: true });
 
     const cloneResult = runGh(
-      'repo clone ' + repo + ' "' + tmpDir + '" -- --depth 1',
+      ['repo', 'clone', repo, tmpDir, '--', '--depth', '1'],
       { timeoutMs: 60000 }
     );
     if (!cloneResult.ok) {
@@ -322,7 +325,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     }
 
     try {
-      execSync('git checkout -b "' + branch + '"', { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
+      execFileSync('git', ['checkout', '-b', branch], { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
     } catch (e) {
       console.warn('[SelfPR] Branch creation failed: ' + (e.message || e));
       return { attempted: false, reason: 'branch_failed' };
@@ -339,14 +342,15 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     }
 
     try {
-      execSync('git add -A', { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
-      const statusOut = execSync('git status --porcelain', { cwd: tmpDir, timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
+      execFileSync('git', ['add', '-A'], { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
+      const statusOut = execFileSync('git', ['status', '--porcelain'], { cwd: tmpDir, timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
       if (!statusOut || !statusOut.trim()) {
         console.log('[SelfPR] No changes to commit in public repo clone.');
         return { attempted: false, reason: 'no_public_diff' };
       }
-      execSync(
-        'git commit -m "' + title.replace(/"/g, '\\"') + '"',
+      execFileSync(
+        'git',
+        ['commit', '-m', title],
         { cwd: tmpDir, timeout: 10000, env: Object.assign({}, process.env, { GIT_AUTHOR_NAME: 'evolver-bot', GIT_AUTHOR_EMAIL: 'evolver-bot@evomap.ai', GIT_COMMITTER_NAME: 'evolver-bot', GIT_COMMITTER_EMAIL: 'evolver-bot@evomap.ai' }) }
       );
     } catch (e) {
@@ -355,7 +359,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     }
 
     try {
-      execSync('git push origin "' + branch + '"', { cwd: tmpDir, timeout: 30000 });
+      execFileSync('git', ['push', 'origin', branch], { cwd: tmpDir, timeout: 30000 });
     } catch (e) {
       console.warn('[SelfPR] Push failed: ' + (e.message || e));
       return { attempted: false, reason: 'push_failed' };
@@ -365,11 +369,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     fs.writeFileSync(bodyFile, body);
 
     const prResult = runGh(
-      'pr create --repo ' + repo +
-      ' --head "' + branch + '"' +
-      ' --title "' + title.replace(/"/g, '\\"') + '"' +
-      ' --body-file "' + bodyFile + '"' +
-      ' --label "auto-mutation"',
+      ['pr', 'create', '--repo', repo, '--head', branch, '--title', title, '--body-file', bodyFile, '--label', 'auto-mutation'],
       { cwd: tmpDir, timeoutMs: 30000 }
     );
 

--- a/src/gep/validator/sandboxExecutor.js
+++ b/src/gep/validator/sandboxExecutor.js
@@ -74,6 +74,26 @@ function assertNodeCommandSafe(parsed) {
   }
 }
 
+function assertScriptPathSafe(parsed, cwd) {
+  if (parsed.executable !== 'node') return;
+  const firstPositional = parsed.args.find((a) => !a.startsWith('-'));
+  if (!firstPositional) {
+    throw new Error('missing_script_file');
+  }
+  if (path.isAbsolute(firstPositional)) {
+    throw new Error('absolute_script_path_not_allowed');
+  }
+  const resolvedCwd = path.resolve(String(cwd || '.'));
+  const resolvedScript = path.resolve(resolvedCwd, firstPositional);
+  const rel = path.relative(resolvedCwd, resolvedScript);
+  if (!rel || rel === '..' || rel.startsWith('..' + path.sep) || path.isAbsolute(rel)) {
+    throw new Error('script_path_escapes_sandbox');
+  }
+  if (!fs.existsSync(resolvedScript)) {
+    throw new Error('script_not_found_in_sandbox');
+  }
+}
+
 // Parse a command string into executable + argv array, supporting single and
 // double quotes. This is a minimal parser and does NOT expand environment
 // variables, globs, redirects, pipes, or subshells. If the command string
@@ -193,6 +213,7 @@ function runSingleCommand(cmd, opts) {
     try {
       parsed = parseCommand(String(cmd));
       assertNodeCommandSafe(parsed);
+      assertScriptPathSafe(parsed, cwd);
     } catch (err) {
       resolve({
         cmd: String(cmd),
@@ -390,6 +411,7 @@ module.exports = {
   buildSandboxEnv,
   parseCommand,
   assertNodeCommandSafe,
+  assertScriptPathSafe,
   ALLOWED_EXECUTABLES,
   BLOCKED_NODE_FLAGS,
   DEFAULT_CMD_TIMEOUT_MS,

--- a/src/ops/lifecycle.js
+++ b/src/ops/lifecycle.js
@@ -5,7 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execFileSync, spawn } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -34,13 +34,22 @@ function sleepMs(ms) {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
 }
 
-function execText(command) {
-    return execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: MAX_EXEC_BUFFER });
+function execText(file, args) {
+    return execFileSync(file, Array.isArray(args) ? args : [], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        maxBuffer: MAX_EXEC_BUFFER,
+        windowsHide: true,
+    });
 }
 
 function listProcesses() {
     if (process.platform === 'win32') {
-        var out = execText('powershell -NoProfile -Command "Get-CimInstance Win32_Process | ForEach-Object { $cmd = if ($_.CommandLine) { $_.CommandLine } else { \'\' }; Write-Output (\'{0}\\t{1}\' -f $_.ProcessId, $cmd) }"');
+        var out = execText('powershell', [
+            '-NoProfile',
+            '-Command',
+            "Get-CimInstance Win32_Process | ForEach-Object { $cmd = if ($_.CommandLine) { $_.CommandLine } else { '' }; Write-Output ('{0}`t{1}' -f $_.ProcessId, $cmd) }",
+        ]);
         var procs = [];
         for (var line of out.split(/\r?\n/)) {
             if (!line || !line.trim()) continue;
@@ -52,7 +61,7 @@ function listProcesses() {
         }
         return procs;
     }
-    var psOut = execText('ps -e -o pid=,args=');
+    var psOut = execText('ps', ['-e', '-o', 'pid=,args=']);
     var unixProcs = [];
     for (var psLine of psOut.split('\n')) {
         var trimmed = psLine.trim();

--- a/src/ops/self_repair.js
+++ b/src/ops/self_repair.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -12,20 +12,29 @@ const { getWorkspaceRoot } = require('../gep/paths');
 
 var LOCK_MAX_AGE_MS = require('../config').LOCK_MAX_AGE_MS;
 
+function runGit(args, options) {
+    return execFileSync('git', Array.isArray(args) ? args : [], Object.assign({
+        encoding: 'utf8',
+        stdio: 'ignore',
+        maxBuffer: MAX_EXEC_BUFFER,
+        windowsHide: true,
+    }, options || {}));
+}
+
 function repair(gitRoot) {
     var root = gitRoot || getWorkspaceRoot();
     var repaired = [];
 
     // 1. Abort pending rebase
     try {
-        execSync('git rebase --abort', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
+        runGit(['rebase', '--abort'], { cwd: root });
         repaired.push('rebase_aborted');
         console.log('[SelfRepair] Aborted pending rebase.');
     } catch (e) {}
 
     // 2. Abort pending merge
     try {
-        execSync('git merge --abort', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
+        runGit(['merge', '--abort'], { cwd: root });
         repaired.push('merge_aborted');
         console.log('[SelfRepair] Aborted pending merge.');
     } catch (e) {}
@@ -48,9 +57,9 @@ function repair(gitRoot) {
     // Only enabled if explicitly called with --force-reset or EVOLVE_GIT_RESET=true
     if (process.env.EVOLVE_GIT_RESET === 'true') {
         try {
-            console.log('[SelfRepair] Resetting local branch to origin/main (HARD reset)...');
-            execSync('git fetch origin main', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
-            execSync('git reset --hard origin/main', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
+            console.warn('[SelfRepair] EVOLVE_GIT_RESET=true set. Resetting local branch to origin/main (HARD reset).');
+            runGit(['fetch', 'origin', 'main'], { cwd: root });
+            runGit(['reset', '--hard', 'origin/main'], { cwd: root });
             repaired.push('hard_reset_to_origin');
         } catch (e) {
             console.warn('[SelfRepair] Hard reset failed: ' + e.message);
@@ -58,7 +67,7 @@ function repair(gitRoot) {
     } else {
         // Safe fetch
         try {
-            execSync('git fetch origin', { cwd: root, stdio: 'ignore', timeout: 30000, maxBuffer: MAX_EXEC_BUFFER });
+            runGit(['fetch', 'origin'], { cwd: root, timeout: 30000 });
             repaired.push('fetch_ok');
         } catch (e) {
             console.warn('[SelfRepair] git fetch failed: ' + e.message);

--- a/src/ops/skills_monitor.js
+++ b/src/ops/skills_monitor.js
@@ -29,6 +29,9 @@ try {
     }
 } catch (e) { /* ignore */ }
 
+const ALLOW_AUTO_NPM_INSTALL =
+    String(process.env.EVOLVER_ENABLE_SKILL_AUTO_INSTALL || '').toLowerCase() === 'true';
+
 function checkSkill(skillName) {
     var SKILLS_DIR = getSkillsDir();
     if (IGNORE_LIST.has(skillName)) return null;
@@ -92,6 +95,10 @@ function autoHeal(skillName, issues) {
 
     for (var i = 0; i < issues.length; i++) {
         if (issues[i] === 'Missing node_modules (needs npm install)' || issues[i] === 'Empty node_modules (needs npm install)') {
+            if (!ALLOW_AUTO_NPM_INSTALL) {
+                console.warn('[SkillsMonitor] Auto npm install disabled for ' + skillName + '. Set EVOLVER_ENABLE_SKILL_AUTO_INSTALL=true to opt in.');
+                continue;
+            }
             try {
                 // Remove package-lock.json if it exists to prevent conflict errors
                 try { fs.unlinkSync(path.join(skillPath, 'package-lock.json')); } catch (e) {}

--- a/src/proxy/extensions/skillUpdater.js
+++ b/src/proxy/extensions/skillUpdater.js
@@ -5,9 +5,11 @@ const path = require('path');
 const crypto = require('crypto');
 
 const MAX_SKILL_UPDATE_BYTES = 512 * 1024;
+const ALLOW_UNSIGNED_SKILL_UPDATE =
+  String(process.env.EVOMAP_ALLOW_UNSIGNED_SKILL_UPDATE || '').toLowerCase() === 'true';
 
 function verifyPayloadHash(content, expectedHash) {
-  if (!expectedHash) return true;
+  if (!expectedHash) return ALLOW_UNSIGNED_SKILL_UPDATE;
   const actual = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
   return actual === String(expectedHash).toLowerCase();
 }
@@ -41,7 +43,7 @@ class SkillUpdater {
       return false;
     }
     if (!verifyPayloadHash(content, payload.sha256 || payload.content_sha256)) {
-      this.logger.warn('[skill-updater] skill_update hash mismatch');
+      this.logger.warn('[skill-updater] skill_update missing hash or hash mismatch');
       return false;
     }
 

--- a/src/proxy/extensions/skillUpdater.js
+++ b/src/proxy/extensions/skillUpdater.js
@@ -2,6 +2,15 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+
+const MAX_SKILL_UPDATE_BYTES = 512 * 1024;
+
+function verifyPayloadHash(content, expectedHash) {
+  if (!expectedHash) return true;
+  const actual = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+  return actual === String(expectedHash).toLowerCase();
+}
 
 class SkillUpdater {
   constructor({ store, skillPath, logger } = {}) {
@@ -27,17 +36,28 @@ class SkillUpdater {
       this.logger.warn('[skill-updater] No content in skill_update message');
       return false;
     }
+    if (Buffer.byteLength(content, 'utf8') > MAX_SKILL_UPDATE_BYTES) {
+      this.logger.warn('[skill-updater] skill_update content too large');
+      return false;
+    }
+    if (!verifyPayloadHash(content, payload.sha256 || payload.content_sha256)) {
+      this.logger.warn('[skill-updater] skill_update hash mismatch');
+      return false;
+    }
 
     try {
       const dir = path.dirname(this.skillPath);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 
       if (fs.existsSync(this.skillPath)) {
         const backupPath = this.skillPath + '.bak';
         fs.copyFileSync(this.skillPath, backupPath);
       }
 
-      fs.writeFileSync(this.skillPath, content, 'utf8');
+      const tmpPath = this.skillPath + '.tmp';
+      fs.writeFileSync(tmpPath, content, { encoding: 'utf8', mode: 0o600 });
+      fs.renameSync(tmpPath, this.skillPath);
+      try { fs.chmodSync(this.skillPath, 0o600); } catch {}
       this.store.setState('last_skill_update', new Date().toISOString());
       this.store.setState('skill_version', payload.version || 'unknown');
       this.logger.log(`[skill-updater] Updated skill.md (version: ${payload.version || 'unknown'})`);

--- a/src/proxy/mailbox/store.js
+++ b/src/proxy/mailbox/store.js
@@ -7,6 +7,8 @@ const crypto = require('crypto');
 const DEFAULT_CHANNEL = 'evomap-hub';
 const SCHEMA_VERSION = 1;
 const PROXY_PROTOCOL_VERSION = '0.1.0';
+const PRIVATE_FILE_MODE = 0o600;
+const PRIVATE_DIR_MODE = 0o700;
 
 // Merge `fields` into `target` while stripping keys that can mutate the
 // prototype chain. Mailbox rows are persisted as JSONL and rebuilt on
@@ -69,7 +71,10 @@ function safeParse(payload) {
 }
 
 function appendLine(filePath, obj) {
-  fs.appendFileSync(filePath, JSON.stringify(obj) + '\n', 'utf8');
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  fs.appendFileSync(filePath, JSON.stringify(obj) + '\n', { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
+  try { fs.chmodSync(filePath, PRIVATE_FILE_MODE); } catch {}
 }
 
 function readLines(filePath) {
@@ -90,7 +95,8 @@ function readLines(filePath) {
 class MailboxStore {
   constructor(dataDir) {
     if (!dataDir) throw new Error('dataDir is required');
-    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+    try { fs.chmodSync(dataDir, PRIVATE_DIR_MODE); } catch {}
     this.dataDir = dataDir;
 
     this._messagesFile = path.join(dataDir, 'messages.jsonl');
@@ -134,10 +140,11 @@ class MailboxStore {
 
   _persistState() {
     const dir = path.dirname(this._stateFile);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
     const tmp = `${this._stateFile}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(this._state, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(tmp, JSON.stringify(this._state, null, 2) + '\n', { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
     fs.renameSync(tmp, this._stateFile);
+    try { fs.chmodSync(this._stateFile, PRIVATE_FILE_MODE); } catch {}
   }
 
   _rebuildIndex() {

--- a/src/proxy/server/http.js
+++ b/src/proxy/server/http.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const http = require('http');
-const { writeSettings, readSettings, clearSettings, clearIfStale } = require('./settings');
+const { writeSettings, clearSettings, clearIfStale, createProxyAuthToken } = require('./settings');
 
 const MAX_PORT_ATTEMPTS = 100;
 const DEFAULT_PORT = 19820;
@@ -89,6 +89,8 @@ class ProxyHttpServer {
     this.actualPort = null;
     this.logger = logger || console;
     this.server = null;
+    this.requireAuth = String(process.env.EVOMAP_PROXY_REQUIRE_AUTH || 'true').toLowerCase() !== 'false';
+    this.authToken = createProxyAuthToken();
   }
 
   async start() {
@@ -106,6 +108,7 @@ class ProxyHttpServer {
             url,
             pid: process.pid,
             started_at: new Date().toISOString(),
+            auth_token: this.authToken,
           },
         });
         this.logger.log(`[proxy] HTTP server listening on ${url}`);
@@ -127,6 +130,13 @@ class ProxyHttpServer {
   async _handleRequest(req, res) {
     const url = new URL(req.url, `http://127.0.0.1:${this.actualPort}`);
     const routeKey = `${req.method} ${url.pathname}`;
+
+    if (this.requireAuth) {
+      const provided = req.headers['x-evomap-proxy-token'];
+      if (!provided || provided !== this.authToken) {
+        return sendJson(res, 401, { error: 'Unauthorized' });
+      }
+    }
 
     const paramMatch = this._matchRoute(req.method, url.pathname);
 

--- a/src/proxy/server/settings.js
+++ b/src/proxy/server/settings.js
@@ -5,31 +5,43 @@ const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 
-const SETTINGS_DIR = path.join(os.homedir(), '.evolver');
-const SETTINGS_FILE = path.join(SETTINGS_DIR, 'settings.json');
+const DEFAULT_SETTINGS_DIR = path.join(os.homedir(), '.evolver');
+const SETTINGS_DIR = DEFAULT_SETTINGS_DIR;
+const SETTINGS_FILE = path.join(DEFAULT_SETTINGS_DIR, 'settings.json');
 const FILE_MODE = 0o600;
 const DIR_MODE = 0o700;
 
+function resolveSettingsDir() {
+  return process.env.EVOLVER_SETTINGS_DIR || DEFAULT_SETTINGS_DIR;
+}
+
+function resolveSettingsFile() {
+  return path.join(resolveSettingsDir(), 'settings.json');
+}
+
 function ensureSettingsDir() {
-  if (!fs.existsSync(SETTINGS_DIR)) {
-    fs.mkdirSync(SETTINGS_DIR, { recursive: true, mode: DIR_MODE });
+  const settingsDir = resolveSettingsDir();
+  if (!fs.existsSync(settingsDir)) {
+    fs.mkdirSync(settingsDir, { recursive: true, mode: DIR_MODE });
     return;
   }
-  try { fs.chmodSync(SETTINGS_DIR, DIR_MODE); } catch {}
+  try { fs.chmodSync(settingsDir, DIR_MODE); } catch {}
 }
 
 function writeSettingsFile(data) {
   ensureSettingsDir();
-  const tmp = SETTINGS_FILE + '.tmp';
+  const settingsFile = resolveSettingsFile();
+  const tmp = settingsFile + '.tmp';
   fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { encoding: 'utf8', mode: FILE_MODE });
-  fs.renameSync(tmp, SETTINGS_FILE);
-  try { fs.chmodSync(SETTINGS_FILE, FILE_MODE); } catch {}
+  fs.renameSync(tmp, settingsFile);
+  try { fs.chmodSync(settingsFile, FILE_MODE); } catch {}
 }
 
 function readSettings() {
   try {
-    if (fs.existsSync(SETTINGS_FILE)) {
-      return JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8'));
+    const settingsFile = resolveSettingsFile();
+    if (fs.existsSync(settingsFile)) {
+      return JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
     }
   } catch {}
   return {};
@@ -44,7 +56,8 @@ function writeSettings(data) {
 
 function clearSettings() {
   try {
-    if (fs.existsSync(SETTINGS_FILE)) {
+    const settingsFile = resolveSettingsFile();
+    if (fs.existsSync(settingsFile)) {
       const current = readSettings();
       delete current.proxy;
       writeSettingsFile(current);
@@ -102,6 +115,8 @@ module.exports = {
   getProxyAuthToken,
   getProxyRequestHeaders,
   createProxyAuthToken,
+  resolveSettingsDir,
+  resolveSettingsFile,
   SETTINGS_DIR,
   SETTINGS_FILE,
 };

--- a/src/proxy/server/settings.js
+++ b/src/proxy/server/settings.js
@@ -3,9 +3,28 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 
 const SETTINGS_DIR = path.join(os.homedir(), '.evolver');
 const SETTINGS_FILE = path.join(SETTINGS_DIR, 'settings.json');
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+function ensureSettingsDir() {
+  if (!fs.existsSync(SETTINGS_DIR)) {
+    fs.mkdirSync(SETTINGS_DIR, { recursive: true, mode: DIR_MODE });
+    return;
+  }
+  try { fs.chmodSync(SETTINGS_DIR, DIR_MODE); } catch {}
+}
+
+function writeSettingsFile(data) {
+  ensureSettingsDir();
+  const tmp = SETTINGS_FILE + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { encoding: 'utf8', mode: FILE_MODE });
+  fs.renameSync(tmp, SETTINGS_FILE);
+  try { fs.chmodSync(SETTINGS_FILE, FILE_MODE); } catch {}
+}
 
 function readSettings() {
   try {
@@ -17,12 +36,9 @@ function readSettings() {
 }
 
 function writeSettings(data) {
-  if (!fs.existsSync(SETTINGS_DIR)) {
-    fs.mkdirSync(SETTINGS_DIR, { recursive: true });
-  }
   const current = readSettings();
   const merged = { ...current, ...data };
-  fs.writeFileSync(SETTINGS_FILE, JSON.stringify(merged, null, 2), 'utf8');
+  writeSettingsFile(merged);
   return merged;
 }
 
@@ -31,7 +47,7 @@ function clearSettings() {
     if (fs.existsSync(SETTINGS_FILE)) {
       const current = readSettings();
       delete current.proxy;
-      fs.writeFileSync(SETTINGS_FILE, JSON.stringify(current, null, 2), 'utf8');
+      writeSettingsFile(current);
     }
   } catch {}
 }
@@ -61,4 +77,31 @@ function getProxyUrl() {
   return settings.proxy?.url || null;
 }
 
-module.exports = { readSettings, writeSettings, clearSettings, clearIfStale, isStaleProxy, getProxyUrl, SETTINGS_DIR, SETTINGS_FILE };
+function getProxyAuthToken() {
+  const settings = readSettings();
+  return settings.proxy?.auth_token || null;
+}
+
+function getProxyRequestHeaders() {
+  const token = getProxyAuthToken();
+  if (!token) return {};
+  return { 'x-evomap-proxy-token': token };
+}
+
+function createProxyAuthToken() {
+  return crypto.randomBytes(24).toString('hex');
+}
+
+module.exports = {
+  readSettings,
+  writeSettings,
+  clearSettings,
+  clearIfStale,
+  isStaleProxy,
+  getProxyUrl,
+  getProxyAuthToken,
+  getProxyRequestHeaders,
+  createProxyAuthToken,
+  SETTINGS_DIR,
+  SETTINGS_FILE,
+};

--- a/test/extensions.test.js
+++ b/test/extensions.test.js
@@ -30,6 +30,14 @@ describe('SkillUpdater', () => {
     try { fs.rmSync(skillDir, { recursive: true }); } catch {}
   });
 
+  function withHash(content, version) {
+    return {
+      content,
+      version,
+      sha256: require('crypto').createHash('sha256').update(content, 'utf8').digest('hex'),
+    };
+  }
+
   it('updates skill.md from inbound message', () => {
     const skillPath = path.join(skillDir, 'SKILL.md');
     const updater = new SkillUpdater({
@@ -39,7 +47,7 @@ describe('SkillUpdater', () => {
     });
 
     const result = updater.processSkillUpdate({
-      payload: { content: '# Updated Skill\nNew content here.', version: '1.1.0' },
+      payload: withHash('# Updated Skill\nNew content here.', '1.1.0'),
     });
     assert.equal(result, true);
     assert.equal(fs.readFileSync(skillPath, 'utf8'), '# Updated Skill\nNew content here.');
@@ -57,7 +65,7 @@ describe('SkillUpdater', () => {
     });
 
     updater.processSkillUpdate({
-      payload: { content: 'updated content', version: '2.0' },
+      payload: withHash('updated content', '2.0'),
     });
     assert.equal(fs.readFileSync(skillPath, 'utf8'), 'updated content');
     assert.equal(fs.readFileSync(skillPath + '.bak', 'utf8'), 'original content');
@@ -80,6 +88,18 @@ describe('SkillUpdater', () => {
     assert.equal(updater.processSkillUpdate({ payload: {} }), false);
   });
 
+  it('returns false without a payload hash by default', () => {
+    const updater = new SkillUpdater({
+      store,
+      skillPath: path.join(skillDir, 'unsigned.md'),
+      logger: { log: () => {}, warn: () => {}, error: () => {} },
+    });
+    assert.equal(
+      updater.processSkillUpdate({ payload: { content: 'unsigned content', version: '0.1.0' } }),
+      false,
+    );
+  });
+
   it('pollAndApply processes pending skill_update messages', () => {
     const dir2 = tmpDataDir();
     const s2 = new MailboxStore(dir2);
@@ -87,7 +107,7 @@ describe('SkillUpdater', () => {
 
     s2.writeInbound({
       type: 'skill_update',
-      payload: { content: '# Polled skill', version: '3.0' },
+      payload: withHash('# Polled skill', '3.0'),
     });
 
     const updater = new SkillUpdater({

--- a/test/proxyServer.test.js
+++ b/test/proxyServer.test.js
@@ -15,7 +15,9 @@ function tmpDataDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-test-'));
 }
 
-function request(url, method, body) {
+let defaultHeaders = {};
+
+function request(url, method, body, headers) {
   return new Promise((resolve, reject) => {
     const u = new URL(url);
     const payload = body ? JSON.stringify(body) : '';
@@ -24,10 +26,10 @@ function request(url, method, body) {
       port: u.port,
       path: u.pathname + u.search,
       method,
-      headers: {
+      headers: Object.assign({
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(payload),
-      },
+      }, defaultHeaders, headers || {}),
     }, (res) => {
       const chunks = [];
       res.on('data', c => chunks.push(c));
@@ -44,10 +46,12 @@ function request(url, method, body) {
 }
 
 describe('ProxyHttpServer', () => {
-  let store, server, baseUrl, dataDir;
+  let store, server, baseUrl, dataDir, settingsDir;
 
   before(async () => {
     dataDir = tmpDataDir();
+    settingsDir = tmpDataDir();
+    process.env.EVOLVER_SETTINGS_DIR = settingsDir;
     store = new MailboxStore(dataDir);
 
     const mockProxyHandlers = {
@@ -61,12 +65,24 @@ describe('ProxyHttpServer', () => {
     server = new ProxyHttpServer(routes, { port: 39820, logger: { log: () => {}, error: () => {}, warn: () => {} } });
     const info = await server.start();
     baseUrl = info.url;
+    defaultHeaders = { 'x-evomap-proxy-token': server.authToken };
   });
 
   after(async () => {
+    defaultHeaders = {};
     await server.stop();
     store.close();
+    delete process.env.EVOLVER_SETTINGS_DIR;
     try { fs.rmSync(dataDir, { recursive: true }); } catch {}
+    try { fs.rmSync(settingsDir, { recursive: true }); } catch {}
+  });
+
+  it('rejects requests without proxy auth token', async () => {
+    const res = await request(`${baseUrl}/mailbox/list?type=test`, 'GET', null, {
+      'x-evomap-proxy-token': '',
+    });
+    assert.equal(res.status, 401);
+    assert.equal(res.body.error, 'Unauthorized');
   });
 
   describe('POST /mailbox/send', () => {

--- a/test/sandboxExecutor.security.test.js
+++ b/test/sandboxExecutor.security.test.js
@@ -5,8 +5,17 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-const { parseCommand, assertNodeCommandSafe, ALLOWED_EXECUTABLES, BLOCKED_NODE_FLAGS } = require('../src/gep/validator/sandboxExecutor');
+const {
+  parseCommand,
+  assertNodeCommandSafe,
+  assertScriptPathSafe,
+  ALLOWED_EXECUTABLES,
+  BLOCKED_NODE_FLAGS,
+} = require('../src/gep/validator/sandboxExecutor');
 
 test('parseCommand splits a simple command', () => {
   const r = parseCommand('node index.js');
@@ -123,4 +132,39 @@ test('assertNodeCommandSafe accepts well-formed node invocations', () => {
   assert.doesNotThrow(() => assertNodeCommandSafe({ executable: 'node', args: ['index.js'] }));
   assert.doesNotThrow(() => assertNodeCommandSafe({ executable: 'node', args: ['--no-warnings', 'index.js'] }));
   assert.doesNotThrow(() => assertNodeCommandSafe({ executable: 'node', args: ['scripts/validate-suite.js', '--quiet'] }));
+});
+
+test('assertScriptPathSafe rejects absolute and escaping paths', () => {
+  const sandboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-executor-test-'));
+  try {
+    const inSandbox = path.join(sandboxDir, 'ok.js');
+    fs.writeFileSync(inSandbox, 'console.log("ok")\n', 'utf8');
+    assert.doesNotThrow(() => assertScriptPathSafe({ executable: 'node', args: ['ok.js'] }, sandboxDir));
+
+    const parentEscape = path.join('..', 'escape.js');
+    assert.throws(
+      () => assertScriptPathSafe({ executable: 'node', args: [parentEscape] }, sandboxDir),
+      /escapes_sandbox/,
+    );
+
+    const absolute = path.resolve(sandboxDir, 'ok.js');
+    assert.throws(
+      () => assertScriptPathSafe({ executable: 'node', args: [absolute] }, sandboxDir),
+      /absolute_script_path_not_allowed/,
+    );
+  } finally {
+    try { fs.rmSync(sandboxDir, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('assertScriptPathSafe rejects missing script files', () => {
+  const sandboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-executor-test-'));
+  try {
+    assert.throws(
+      () => assertScriptPathSafe({ executable: 'node', args: ['missing.js'] }, sandboxDir),
+      /script_not_found_in_sandbox/,
+    );
+  } finally {
+    try { fs.rmSync(sandboxDir, { recursive: true, force: true }); } catch {}
+  }
 });


### PR DESCRIPTION
## Summary

This PR hardens several readable security-sensitive paths in Evolver and reduces trust in local and remote update flows.

Main changes:
- require auth for the local proxy
- tighten permissions for local settings and mailbox state
- restrict validator sandbox script paths
- disable risky update/install behavior by default
- replace shell-built command execution with argv-based process calls
- add security deployment notes

## Changes

### Local proxy hardening
- added a per-install proxy auth token
- local proxy now requires `x-evomap-proxy-token` by default
- updated local proxy clients to send the auth header
- preserved proxy GET query strings in mailbox transport

Files:
- `src/proxy/server/http.js`
- `src/proxy/server/settings.js`
- `src/gep/mailboxTransport.js`
- `src/atp/hubClient.js`

### File permission hardening
- tightened permissions for proxy settings, mailbox state, and related local files
- added runtime settings dir override support for tests

Files:
- `src/proxy/server/settings.js`
- `src/proxy/mailbox/store.js`
- `test/proxyServer.test.js`

### Validator sandbox restrictions
- reject absolute script paths
- reject path traversal outside the sandbox
- require script targets to exist inside the sandbox

Files:
- `src/gep/validator/sandboxExecutor.js`
- `test/sandboxExecutor.security.test.js`

### Update/install safety
- `force update` now requires explicit opt-in via `EVOLVER_ENABLE_FORCE_UPDATE=true`
- unsigned skill updates are rejected by default
- skill updates now verify content hash when provided
- skill writes are atomic and permissions are tightened
- auto skill install is disabled by default and requires `EVOLVER_ENABLE_SKILL_AUTO_INSTALL=true`

Files:
- `src/forceUpdate.js`
- `src/proxy/extensions/skillUpdater.js`
- `src/ops/skills_monitor.js`
- `test/extensions.test.js`

### Command execution hardening
Replaced several shell-built `execSync(...)` paths with argv-based execution using `execFileSync(...)` or equivalent helpers.

Files:
- `src/gep/selfPR.js`
- `src/gep/idleScheduler.js`
- `src/adapters/scripts/evolver-session-end.js`
- `src/ops/lifecycle.js`
- `src/gep/gitOps.js`
- `src/ops/self_repair.js`

### Security documentation
- added deployment and risk guidance
- linked README security section to the new notes

Files:
- `SECURITY.md`
- `README.md`

## Behavior changes

This PR intentionally changes defaults in a few places:

- local proxy auth is now required by default
- force update is disabled unless explicitly enabled
- unsigned skill updates are rejected by default
- auto skill install is disabled unless explicitly enabled

These changes are intended to reduce accidental exposure and make risky behavior opt-in.

## Validation

Validated with targeted checks in this environment:
- module load checks on modified files
- focused checks for sandbox path guards
- focused checks for signed and unsigned skill update behavior
- focused proxy startup/auth-related test updates

## Test limitation

Full `node --test` execution was not reliably available in this environment due `spawn EPERM`, so I could not confirm a full suite pass here.

## Follow-ups

Not included in this PR:
- true validator network/filesystem isolation at container or OS level
- stronger signature/provenance verification for remote updates beyond payload hash checks
- broader security-focused coverage for all recovery and rollback paths
