### PR TITLE
update(security): harden mailbox, feature flags, issue reporting, and ATP egress

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,6 +410,7 @@ When the evolver detects persistent failures (failure loop or recurring errors w
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `EVOLVER_AUTO_ISSUE` | `true` | Enable/disable auto issue reporting |
+| `EVOLVER_ISSUE_INCLUDE_LOGS` | _(unset = off)_ | Include sanitized session log excerpts in auto-reported issues |
 | `EVOLVER_ISSUE_REPO` | `autogame-17/capability-evolver` | Target GitHub repository (owner/repo) |
 | `EVOLVER_ISSUE_COOLDOWN_MS` | `86400000` (24h) | Cooldown period for the same error signature |
 | `EVOLVER_ISSUE_MIN_STREAK` | `5` | Minimum consecutive failure streak to trigger |

--- a/README.md
+++ b/README.md
@@ -395,7 +395,7 @@ When connected to an [EvoMap Hub](https://evomap.ai), every evolver instance als
 | `EVOLVER_VALIDATOR_MAX_TASKS_PER_CYCLE` | `2` | Max tasks claimed per poll. |
 | `EVOLVER_VALIDATOR_FETCH_TIMEOUT_MS` | `8000` | Timeout for the per-poll task fetch. |
 
-Persistent flag override: when the env is unset, the runtime reads `~/.evomap/feature_flags.json`. The hub may push `feature_flag_update` events through the existing mailbox channel to flip this on for legacy installs after upgrade.
+Persistent flag override: when the env is unset, the runtime reads `~/.evomap/feature_flags.json`. Hub-pushed `feature_flag_update` events are ignored unless `EVOLVER_ENABLE_HUB_FEATURE_FLAGS=true` is explicitly set.
 
 To opt out permanently:
 

--- a/README.md
+++ b/README.md
@@ -420,6 +420,8 @@ Requires `GITHUB_TOKEN` (or `GH_TOKEN` / `GITHUB_PAT`) with `repo` scope. When n
 
 This section describes the execution boundaries and trust model of the Evolver.
 
+Operational guidance for safer deployment lives in [SECURITY.md](SECURITY.md).
+
 ### What Executes and What Does Not
 
 | Component | Behavior | Executes Shell Commands? |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,10 +8,12 @@ Recent security hardening in this branch includes:
 
 - local proxy authentication via per-install token
 - stricter permissions for proxy settings and mailbox state files
+- mailbox payload and batch size limits to reduce local abuse / disk growth
 - validator sandbox path restrictions
 - signed skill update enforcement by default
 - `force update` disabled unless explicitly enabled
 - `skills_monitor` auto-install disabled unless explicitly enabled
+- hub-sourced persisted feature flags disabled unless explicitly enabled
 - argv-based git/process execution in several modules to reduce shell injection risk
 
 ## Deployment Guidance
@@ -33,6 +35,7 @@ These flags materially increase risk and should stay off by default:
 - `EVOLVE_GIT_RESET=true`
 - `EVOLVER_ENABLE_FORCE_UPDATE=true`
 - `EVOLVER_ENABLE_SKILL_AUTO_INSTALL=true`
+- `EVOLVER_ENABLE_HUB_FEATURE_FLAGS=true`
 - `EVOMAP_ALLOW_UNSIGNED_SKILL_UPDATE=true`
 - `EVOMAP_PROXY_REQUIRE_AUTH=false`
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,7 @@ Recent security hardening in this branch includes:
 - `force update` disabled unless explicitly enabled
 - `skills_monitor` auto-install disabled unless explicitly enabled
 - hub-sourced persisted feature flags disabled unless explicitly enabled
+- auto issue reporting now omits sanitized log excerpts unless explicitly enabled
 - argv-based git/process execution in several modules to reduce shell injection risk
 
 ## Deployment Guidance

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,53 @@
+# Security Notes
+
+This document describes the current security posture of the readable parts of this repository and the operating assumptions required for safer deployment.
+
+## Current Hardening
+
+Recent security hardening in this branch includes:
+
+- local proxy authentication via per-install token
+- stricter permissions for proxy settings and mailbox state files
+- validator sandbox path restrictions
+- signed skill update enforcement by default
+- `force update` disabled unless explicitly enabled
+- `skills_monitor` auto-install disabled unless explicitly enabled
+- argv-based git/process execution in several modules to reduce shell injection risk
+
+## Deployment Guidance
+
+Treat Evolver as a privileged local automation tool.
+
+Recommended baseline:
+
+1. Run it on a dedicated user account.
+2. Keep it off shared or multi-tenant hosts.
+3. Prefer offline mode unless Hub features are required.
+4. If validator mode is enabled, run it inside a container or VM with network egress controls.
+5. Do not enable `EVOLVE_GIT_RESET`, `EVOLVER_ENABLE_FORCE_UPDATE`, or `EVOLVER_ENABLE_SKILL_AUTO_INSTALL` unless you have a clear operational reason.
+
+## Sensitive Flags
+
+These flags materially increase risk and should stay off by default:
+
+- `EVOLVE_GIT_RESET=true`
+- `EVOLVER_ENABLE_FORCE_UPDATE=true`
+- `EVOLVER_ENABLE_SKILL_AUTO_INSTALL=true`
+- `EVOMAP_ALLOW_UNSIGNED_SKILL_UPDATE=true`
+- `EVOMAP_PROXY_REQUIRE_AUTH=false`
+
+## Remaining High-Risk Areas
+
+The following areas still deserve deeper audit:
+
+- validator execution isolation beyond path validation
+- Hub trust model and message authenticity
+- any path that can update local skills or fetch remote assets
+- destructive recovery paths guarded by environment variables
+
+## Recommended Next Steps
+
+1. Add container-based validator isolation guidance and example configs.
+2. Add signature verification for remote updates beyond skill payload hash checks.
+3. Add more tests around proxy auth failures and recovery flows.
+4. Add a public security reporting process and maintainer contact.

--- a/src/adapters/scripts/evolver-session-end.js
+++ b/src/adapters/scripts/evolver-session-end.js
@@ -6,7 +6,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync, spawnSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -52,16 +52,38 @@ function findMemoryGraph(evolverRoot) {
 function getGitDiffStats() {
   try {
     const cwd = process.cwd();
-    const stat = execSync('git diff --stat HEAD~1 2>/dev/null || git diff --stat 2>/dev/null || echo ""', {
-      cwd,
-      encoding: 'utf8',
-      timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
-    }).trim();
-    const diffContent = execSync('git diff HEAD~1 --no-color 2>/dev/null || git diff --no-color 2>/dev/null || echo ""', {
-      cwd,
-      encoding: 'utf8',
-      timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
-    }).trim();
+    let stat = '';
+    let diffContent = '';
+    try {
+      stat = execFileSync('git', ['diff', '--stat', 'HEAD~1'], {
+        cwd,
+        encoding: 'utf8',
+        timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+      }).trim();
+    } catch (_) {
+      try {
+        stat = execFileSync('git', ['diff', '--stat'], {
+          cwd,
+          encoding: 'utf8',
+          timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+        }).trim();
+      } catch (_) {}
+    }
+    try {
+      diffContent = execFileSync('git', ['diff', 'HEAD~1', '--no-color'], {
+        cwd,
+        encoding: 'utf8',
+        timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+      }).trim();
+    } catch (_) {
+      try {
+        diffContent = execFileSync('git', ['diff', '--no-color'], {
+          cwd,
+          encoding: 'utf8',
+          timeout: 5000, maxBuffer: MAX_EXEC_BUFFER
+        }).trim();
+      } catch (_) {}
+    }
     const filesChanged = (stat.match(/\d+ files? changed/) || ['0'])[0];
     const insertions = (stat.match(/(\d+) insertions?/) || [null, '0'])[1];
     const deletions = (stat.match(/(\d+) deletions?/) || [null, '0'])[1];

--- a/src/atp/atpExecute.js
+++ b/src/atp/atpExecute.js
@@ -27,6 +27,7 @@ const https = require('https');
 const crypto = require('crypto');
 
 const { computeAssetId } = require('../gep/contentHash');
+const { redactString } = require('../gep/sanitize');
 const {
   getNodeId,
   getHubUrl,
@@ -38,10 +39,26 @@ const { submitDelivery } = require('./hubClient');
 
 const MAX_ANSWER_CHARS = 32000; // cap capsule.content to protect Hub payload limits
 const PUBLISH_TIMEOUT_MS = 15000;
+const MAX_METADATA_ITEMS = 8;
+const MAX_METADATA_STRING = 80;
+
+function _cleanString(value, fallback, maxLength) {
+  const text = redactString(String(value == null ? '' : value)).trim();
+  if (!text) return fallback || '';
+  return text.slice(0, maxLength);
+}
+
+function _cleanList(values, fallback) {
+  const list = Array.isArray(values) ? values : fallback;
+  return list
+    .map(function (item) { return _cleanString(item, '', MAX_METADATA_STRING); })
+    .filter(Boolean)
+    .slice(0, MAX_METADATA_ITEMS);
+}
 
 function _readAnswer(answerFile) {
   const raw = fs.readFileSync(answerFile, 'utf8');
-  const trimmed = String(raw || '').trim();
+  const trimmed = redactString(String(raw || '').trim());
   if (!trimmed) throw new Error('answer file is empty');
   if (trimmed.length > MAX_ANSWER_CHARS) {
     return trimmed.slice(0, MAX_ANSWER_CHARS - 40) + '\n...[TRUNCATED]...';
@@ -50,12 +67,8 @@ function _readAnswer(answerFile) {
 }
 
 function _buildGene(capabilities, signals) {
-  const caps = Array.isArray(capabilities) && capabilities.length > 0
-    ? capabilities.slice(0, 8)
-    : ['general'];
-  const sig = Array.isArray(signals) && signals.length > 0
-    ? signals.slice(0, 8)
-    : ['atp_task'];
+  const caps = _cleanList(capabilities, ['general']);
+  const sig = _cleanList(signals, ['atp_task']);
   const gene = {
     type: 'Gene',
     schema_version: '1.0',
@@ -78,11 +91,11 @@ function _buildGene(capabilities, signals) {
 }
 
 function _buildCapsule({ gene, answer, summary, orderId, taskId, capabilities, signals }) {
-  const caps = Array.isArray(capabilities) ? capabilities.slice(0, 8) : [];
-  const sig = Array.isArray(signals) && signals.length > 0 ? signals.slice(0, 8) : ['atp_task'];
+  const caps = _cleanList(capabilities, []);
+  const sig = _cleanList(signals, ['atp_task']);
   const confidence = 0.9; // merchant self-attested; buyer verify may override
-  const capsuleSummary = String(summary || '').trim()
-    || 'ATP merchant delivery for order ' + String(orderId || '').slice(0, 24);
+  const capsuleSummary = _cleanString(summary, '', 200)
+    || 'ATP merchant delivery for order ' + _cleanString(orderId || '', '', 24);
   const capsule = {
     type: 'Capsule',
     schema_version: '1.0',
@@ -94,7 +107,7 @@ function _buildCapsule({ gene, answer, summary, orderId, taskId, capabilities, s
     blast_radius: { files: 0, lines: Math.min(1000, answer.split('\n').length) },
     outcome: { status: 'success', score: confidence },
     env_fingerprint: { platform: process.platform, arch: process.arch, runtime: 'evolver-atp' },
-    content: answer,
+    content: redactString(String(answer || '')),
     source_type: 'atp_task_executor',
     atp: {
       order_id: orderId || null,

--- a/src/atp/autoDeliver.js
+++ b/src/atp/autoDeliver.js
@@ -24,12 +24,17 @@ const fs = require('fs');
 const path = require('path');
 
 const { getMemoryDir } = require('../gep/paths');
+const { redactString } = require('../gep/sanitize');
 const hubClient = require('./hubClient');
 
 const DEFAULT_POLL_MS = 60 * 1000; // 1 min
 const MIN_POLL_MS = 15 * 1000;
 const LEDGER_FILENAME = 'atp-autodeliver-ledger.json';
 const LEDGER_MAX_ENTRIES = 500;
+const PRIVATE_FILE_MODE = 0o600;
+const PRIVATE_DIR_MODE = 0o700;
+const MAX_SIGNAL_ITEMS = 10;
+const MAX_SIGNAL_LENGTH = 80;
 
 let _started = false;
 let _pollInterval = null;
@@ -65,7 +70,7 @@ function _readLedger() {
 function _writeLedger(ledger) {
   try {
     const dir = getMemoryDir();
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
     // Bound the ledger size so it cannot grow without limit on long-running
     // merchants. Keep the most-recent entries by insertion order.
     const entries = Object.entries(ledger.submitted || {});
@@ -74,8 +79,9 @@ function _writeLedger(ledger) {
       ledger.submitted = trimmed;
     }
     const tmp = _ledgerPath() + '.tmp';
-    fs.writeFileSync(tmp, JSON.stringify(ledger, null, 2));
+    fs.writeFileSync(tmp, JSON.stringify(ledger, null, 2), { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
     fs.renameSync(tmp, _ledgerPath());
+    try { fs.chmodSync(_ledgerPath(), PRIVATE_FILE_MODE); } catch (_) {}
   } catch (_) {
     // Non-fatal: next poll will re-attempt from Hub state. Hub-side
     // submitDelivery is itself idempotent per order id.
@@ -83,6 +89,9 @@ function _writeLedger(ledger) {
 }
 
 function _buildProofPayload(task) {
+  const safeSignals = Array.isArray(task.signals)
+    ? task.signals.map(function (s) { return redactString(String(s || '')).trim().slice(0, MAX_SIGNAL_LENGTH); }).filter(Boolean).slice(0, MAX_SIGNAL_ITEMS)
+    : [];
   // Minimal evidence the Hub's auto verifier will accept. Matches the shape
   // documented in /a2a/atp/deliver: result/output/pass_rate/signals.
   const now = new Date().toISOString();
@@ -91,7 +100,7 @@ function _buildProofPayload(task) {
     asset_id: task.result_asset_id || null,
     completed_at: task.claimed_at || now,
     pass_rate: 1.0,
-    signals: Array.isArray(task.signals) ? task.signals.slice(0, 10) : [],
+    signals: safeSignals,
     submitter: 'evolver_auto_deliver',
   };
 }

--- a/src/atp/heartbeatSignalsHandler.js
+++ b/src/atp/heartbeatSignalsHandler.js
@@ -22,12 +22,15 @@ const fs = require('fs');
 const path = require('path');
 
 const { getMemoryDir } = require('../gep/paths');
+const { redactString } = require('../gep/sanitize');
 const hubClient = require('./hubClient');
 
 const LEDGER_FILENAME = 'atp-autodeliver-ledger.json'; // shared with autoDeliver
 const LEDGER_MAX_ENTRIES = 500;
 const HANDLER_COOLDOWN_MS = 30 * 1000; // rate-limit per-node, independent of ledger
 const SUBMIT_TIMEOUT_MS = 10 * 1000;
+const PRIVATE_FILE_MODE = 0o600;
+const PRIVATE_DIR_MODE = 0o700;
 
 let _inflight = false;
 let _lastRunAt = 0;
@@ -61,14 +64,15 @@ function _readLedger() {
 function _writeLedger(ledger) {
   try {
     const dir = getMemoryDir();
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
     const entries = Object.entries(ledger.submitted || {});
     if (entries.length > LEDGER_MAX_ENTRIES) {
       ledger.submitted = Object.fromEntries(entries.slice(-LEDGER_MAX_ENTRIES));
     }
     const tmp = _ledgerPath() + '.tmp';
-    fs.writeFileSync(tmp, JSON.stringify(ledger, null, 2));
+    fs.writeFileSync(tmp, JSON.stringify(ledger, null, 2), { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
     fs.renameSync(tmp, _ledgerPath());
+    try { fs.chmodSync(_ledgerPath(), PRIVATE_FILE_MODE); } catch (_) {}
   } catch (_) {
     // Non-fatal: Hub submit is idempotent, next heartbeat will retry
   }
@@ -83,7 +87,7 @@ function _buildProofPayload(row) {
     asset_id: row.result_asset_id || null,
     completed_at: new Date().toISOString(),
     pass_rate: 1.0,
-    submitter: 'evolver_heartbeat_deliver',
+    submitter: redactString('evolver_heartbeat_deliver'),
   };
 }
 

--- a/src/atp/hubClient.js
+++ b/src/atp/hubClient.js
@@ -16,7 +16,7 @@
 
 const http = require('http');
 const { getHubUrl, buildHubHeaders, getNodeId } = require('../gep/a2aProtocol');
-const { getProxyUrl } = require('../proxy/server/settings');
+const { getProxyUrl, getProxyRequestHeaders } = require('../proxy/server/settings');
 
 function _isProxyMode() {
   if (process.env.EVOMAP_PROXY === '1') return true;
@@ -33,7 +33,7 @@ function _proxyRequest(method, path, body, timeoutMs) {
 
   return new Promise(function (resolve) {
     const payload = body ? JSON.stringify(body) : '';
-    const headers = { 'Content-Type': 'application/json' };
+    const headers = Object.assign({ 'Content-Type': 'application/json' }, getProxyRequestHeaders());
     if (payload) headers['Content-Length'] = Buffer.byteLength(payload);
 
     const req = http.request(

--- a/src/atp/serviceHelper.js
+++ b/src/atp/serviceHelper.js
@@ -1,6 +1,60 @@
 // ATP Service Helper -- wraps marketplace service publishing for merchant agents.
 
 const { getNodeId, buildHubHeaders, getHubUrl } = require('../gep/a2aProtocol');
+const { redactString } = require('../gep/sanitize');
+
+const MAX_TITLE_LENGTH = 120;
+const MAX_DESCRIPTION_LENGTH = 1000;
+const MAX_LIST_ITEMS = 12;
+const MAX_LIST_ITEM_LENGTH = 80;
+const ALLOWED_EXECUTION_MODES = new Set(['exclusive', 'open', 'swarm']);
+
+function cleanText(value, fallback, maxLength) {
+  const text = redactString(String(value == null ? '' : value)).trim();
+  if (!text) return fallback || '';
+  return text.slice(0, maxLength);
+}
+
+function cleanStringList(values) {
+  if (!Array.isArray(values)) return [];
+  return values
+    .map(function (item) { return cleanText(item, '', MAX_LIST_ITEM_LENGTH); })
+    .filter(Boolean)
+    .slice(0, MAX_LIST_ITEMS);
+}
+
+function normalizeExecutionMode(value) {
+  const mode = String(value || 'exclusive').trim().toLowerCase();
+  return ALLOWED_EXECUTION_MODES.has(mode) ? mode : 'exclusive';
+}
+
+function sanitizeServicePayload(svc) {
+  const input = svc || {};
+  return {
+    title: cleanText(input.title, '', MAX_TITLE_LENGTH),
+    description: cleanText(input.description, '', MAX_DESCRIPTION_LENGTH),
+    capabilities: cleanStringList(input.capabilities),
+    use_cases: cleanStringList(input.useCases),
+    price_per_task: Math.max(1, Math.round(Number(input.pricePerTask) || 10)),
+    execution_mode: normalizeExecutionMode(input.executionMode),
+    max_concurrent: Math.max(1, Math.min(50, Math.round(Number(input.maxConcurrent) || 3))),
+    recipe_id: input.recipeId == null || input.recipeId === '' ? undefined : cleanText(input.recipeId, '', MAX_LIST_ITEM_LENGTH),
+  };
+}
+
+function sanitizeServiceUpdates(updates) {
+  const input = updates || {};
+  const out = {};
+  if (Object.prototype.hasOwnProperty.call(input, 'title')) out.title = cleanText(input.title, '', MAX_TITLE_LENGTH);
+  if (Object.prototype.hasOwnProperty.call(input, 'description')) out.description = cleanText(input.description, '', MAX_DESCRIPTION_LENGTH);
+  if (Object.prototype.hasOwnProperty.call(input, 'capabilities')) out.capabilities = cleanStringList(input.capabilities);
+  if (Object.prototype.hasOwnProperty.call(input, 'useCases')) out.use_cases = cleanStringList(input.useCases);
+  if (Object.prototype.hasOwnProperty.call(input, 'pricePerTask')) out.price_per_task = Math.max(1, Math.round(Number(input.pricePerTask) || 10));
+  if (Object.prototype.hasOwnProperty.call(input, 'executionMode')) out.execution_mode = normalizeExecutionMode(input.executionMode);
+  if (Object.prototype.hasOwnProperty.call(input, 'maxConcurrent')) out.max_concurrent = Math.max(1, Math.min(50, Math.round(Number(input.maxConcurrent) || 3)));
+  if (Object.prototype.hasOwnProperty.call(input, 'recipeId')) out.recipe_id = input.recipeId == null || input.recipeId === '' ? undefined : cleanText(input.recipeId, '', MAX_LIST_ITEM_LENGTH);
+  return out;
+}
 
 /**
  * Publish a ServiceListing via the Hub marketplace API.
@@ -23,16 +77,18 @@ async function publishService(svc) {
   const endpoint = hubUrl.replace(/\/+$/, '') + '/a2a/service/publish';
   const timeout = require('../config').HTTP_TRANSPORT_TIMEOUT_MS;
 
+  const payload = sanitizeServicePayload(svc);
+  if (!payload.title) return { ok: false, error: 'title is required' };
   const body = {
     sender_id: nodeId,
-    title: svc.title,
-    description: svc.description,
-    capabilities: svc.capabilities,
-    use_cases: svc.useCases,
-    price_per_task: Math.max(1, Math.round(Number(svc.pricePerTask) || 10)),
-    execution_mode: svc.executionMode || 'exclusive',
-    max_concurrent: Math.max(1, Math.round(Number(svc.maxConcurrent) || 3)),
-    recipe_id: svc.recipeId,
+    title: payload.title,
+    description: payload.description,
+    capabilities: payload.capabilities,
+    use_cases: payload.use_cases,
+    price_per_task: payload.price_per_task,
+    execution_mode: payload.execution_mode,
+    max_concurrent: payload.max_concurrent,
+    recipe_id: payload.recipe_id,
   };
 
   try {
@@ -70,8 +126,8 @@ async function updateService(listingId, updates) {
 
   const body = {
     sender_id: nodeId,
-    listing_id: listingId,
-    ...updates,
+    listing_id: cleanText(listingId, '', MAX_LIST_ITEM_LENGTH),
+    ...sanitizeServiceUpdates(updates),
   };
 
   try {
@@ -96,4 +152,6 @@ async function updateService(listingId, updates) {
 module.exports = {
   publishService,
   updateService,
+  sanitizeServicePayload,
+  sanitizeServiceUpdates,
 };

--- a/src/forceUpdate.js
+++ b/src/forceUpdate.js
@@ -4,6 +4,7 @@ const { execSync } = require('child_process');
 const { getRepoRoot } = require('./gep/paths');
 
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
+const FORCE_UPDATE_ENABLED = String(process.env.EVOLVER_ENABLE_FORCE_UPDATE || '').toLowerCase() === 'true';
 
 // Force Update: triggered by Hub when version is critically outdated.
 // Extracted from src/evolve.js so both the evolve main loop and heartbeat
@@ -14,6 +15,14 @@ function executeForceUpdate(forceUpdate) {
   const REPO_ROOT = getRepoRoot();
   const requiredVersion = String(forceUpdate.required_version || '').replace(/^>=/, '');
   console.log('[ForceUpdate] Starting multi-channel update (target: >=' + requiredVersion + ')');
+
+  if (!FORCE_UPDATE_ENABLED) {
+    console.warn('[ForceUpdate] Automatic force update is disabled. Set EVOLVER_ENABLE_FORCE_UPDATE=true to opt in.');
+    if (forceUpdate && forceUpdate.release_url) {
+      console.warn('[ForceUpdate] Manual update URL: ' + forceUpdate.release_url);
+    }
+    return false;
+  }
 
   function parseVer(v) {
     var m = String(v || '').match(/(\d+)\.(\d+)\.(\d+)/);

--- a/src/gep/featureFlags.js
+++ b/src/gep/featureFlags.js
@@ -19,9 +19,25 @@ const os = require('os');
 const FLAGS_DIR = path.join(os.homedir(), '.evomap');
 const FLAGS_FILE = path.join(FLAGS_DIR, 'feature_flags.json');
 const LOCAL_FLAGS_FILE = path.resolve(__dirname, '..', '..', '.evomap_feature_flags.json');
+const ALLOWED_FLAGS = new Map([
+  ['validator_enabled', function (value) { return typeof value === 'boolean'; }],
+]);
 
 let _cache = null;
 let _cacheLoaded = false;
+
+function _normalizeSource(source) {
+  return typeof source === 'string' && source ? source.trim().toLowerCase() : 'unknown';
+}
+
+function _isHubSource(source) {
+  return source === 'hub_mailbox' || source === 'hub_event' || source === 'hub';
+}
+
+function _isHubFeatureFlagsEnabled() {
+  const raw = String(process.env.EVOLVER_ENABLE_HUB_FEATURE_FLAGS || '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
 
 function _readFile(p) {
   try {
@@ -77,10 +93,14 @@ function readFeatureFlag(key) {
  */
 function writeFeatureFlag(key, value, source) {
   if (!key || typeof key !== 'string') return false;
+  const validator = ALLOWED_FLAGS.get(key);
+  if (typeof validator !== 'function' || !validator(value)) return false;
+  const normalizedSource = _normalizeSource(source);
+  if (_isHubSource(normalizedSource) && !_isHubFeatureFlagsEnabled()) return false;
   const all = _loadFromDisk();
   all[key] = {
     value,
-    source: typeof source === 'string' && source ? source : 'unknown',
+    source: normalizedSource,
     updatedAt: new Date().toISOString(),
   };
   const ok = _writeToDisk(all);
@@ -111,4 +131,5 @@ module.exports = {
   _resetCacheForTests,
   FLAGS_FILE,
   LOCAL_FLAGS_FILE,
+  ALLOWED_FLAGS,
 };

--- a/src/gep/gitOps.js
+++ b/src/gep/gitOps.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const { getRepoRoot } = require('./paths');
 
 // 10 MB — prevents RangeError: stdout maxBuffer length exceeded on large
@@ -11,15 +11,23 @@ const { getRepoRoot } = require('./paths');
 // on repos with large refactors (see GHSA reports / issue #451).
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
 
-function runCmd(cmd, opts = {}) {
+function runCmd(args, opts = {}) {
+  const argv = Array.isArray(args) ? args : [];
   const cwd = opts.cwd || getRepoRoot();
   const timeoutMs = Number.isFinite(Number(opts.timeoutMs)) ? Number(opts.timeoutMs) : 120000;
-  return execSync(cmd, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], timeout: timeoutMs, maxBuffer: MAX_EXEC_BUFFER, windowsHide: true });
+  return execFileSync('git', argv, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: timeoutMs,
+    maxBuffer: MAX_EXEC_BUFFER,
+    windowsHide: true,
+  });
 }
 
-function tryRunCmd(cmd, opts = {}) {
+function tryRunCmd(args, opts = {}) {
   try {
-    return { ok: true, out: runCmd(cmd, opts), err: '' };
+    return { ok: true, out: runCmd(args, opts), err: '' };
   } catch (e) {
     const stderr = e && e.stderr ? String(e.stderr) : '';
     const stdout = e && e.stdout ? String(e.stdout) : '';
@@ -47,17 +55,17 @@ function countFileLines(absPath) {
 
 function gitListChangedFiles({ repoRoot }) {
   const files = new Set();
-  const s1 = tryRunCmd('git diff --name-only', { cwd: repoRoot, timeoutMs: 60000 });
+  const s1 = tryRunCmd(['diff', '--name-only'], { cwd: repoRoot, timeoutMs: 60000 });
   if (s1.ok) for (const line of String(s1.out).split('\n').map(l => l.trim()).filter(Boolean)) files.add(line);
-  const s2 = tryRunCmd('git diff --cached --name-only', { cwd: repoRoot, timeoutMs: 60000 });
+  const s2 = tryRunCmd(['diff', '--cached', '--name-only'], { cwd: repoRoot, timeoutMs: 60000 });
   if (s2.ok) for (const line of String(s2.out).split('\n').map(l => l.trim()).filter(Boolean)) files.add(line);
-  const s3 = tryRunCmd('git ls-files --others --exclude-standard', { cwd: repoRoot, timeoutMs: 60000 });
+  const s3 = tryRunCmd(['ls-files', '--others', '--exclude-standard'], { cwd: repoRoot, timeoutMs: 60000 });
   if (s3.ok) for (const line of String(s3.out).split('\n').map(l => l.trim()).filter(Boolean)) files.add(line);
   return Array.from(files);
 }
 
 function gitListUntrackedFiles(repoRoot) {
-  const r = tryRunCmd('git ls-files --others --exclude-standard', { cwd: repoRoot, timeoutMs: 60000 });
+  const r = tryRunCmd(['ls-files', '--others', '--exclude-standard'], { cwd: repoRoot, timeoutMs: 60000 });
   if (!r.ok) return [];
   return String(r.out).split('\n').map(l => l.trim()).filter(Boolean);
 }
@@ -66,9 +74,9 @@ const DIFF_SNAPSHOT_MAX_CHARS = 8000;
 
 function captureDiffSnapshot(repoRoot) {
   const parts = [];
-  const unstaged = tryRunCmd('git diff', { cwd: repoRoot, timeoutMs: 30000 });
+  const unstaged = tryRunCmd(['diff'], { cwd: repoRoot, timeoutMs: 30000 });
   if (unstaged.ok && unstaged.out) parts.push(String(unstaged.out));
-  const staged = tryRunCmd('git diff --cached', { cwd: repoRoot, timeoutMs: 30000 });
+  const staged = tryRunCmd(['diff', '--cached'], { cwd: repoRoot, timeoutMs: 30000 });
   if (staged.ok && staged.out) parts.push(String(staged.out));
   let combined = parts.join('\n');
   if (combined.length > DIFF_SNAPSHOT_MAX_CHARS) {
@@ -79,9 +87,10 @@ function captureDiffSnapshot(repoRoot) {
 
 function isGitRepo(dir) {
   try {
-    execSync('git rev-parse --git-dir', {
+    execFileSync('git', ['rev-parse', '--git-dir'], {
       cwd: dir, encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'], timeout: 5000, maxBuffer: MAX_EXEC_BUFFER,
+      windowsHide: true,
     });
     return true;
   } catch (_) {
@@ -139,20 +148,20 @@ function rollbackTracked(repoRoot) {
 
   if (mode === 'stash') {
     const stashRef = 'evolver-rollback-' + Date.now();
-    const result = tryRunCmd('git stash push -m "' + stashRef + '" --include-untracked', { cwd: repoRoot, timeoutMs: 60000 });
+    const result = tryRunCmd(['stash', 'push', '-m', stashRef, '--include-untracked'], { cwd: repoRoot, timeoutMs: 60000 });
     if (result.ok) {
       console.log('[Rollback] Changes stashed with ref: ' + stashRef + '. Recover with "git stash list" and "git stash pop".');
     } else {
       console.log('[Rollback] Stash failed or no changes, using hard reset');
-      tryRunCmd('git restore --staged --worktree .', { cwd: repoRoot, timeoutMs: 60000 });
-      tryRunCmd('git reset --hard', { cwd: repoRoot, timeoutMs: 60000 });
+      tryRunCmd(['restore', '--staged', '--worktree', '.'], { cwd: repoRoot, timeoutMs: 60000 });
+      tryRunCmd(['reset', '--hard'], { cwd: repoRoot, timeoutMs: 60000 });
     }
     return;
   }
 
   console.log('[Rollback] EVOLVER_ROLLBACK_MODE=hard, resetting tracked files in: ' + repoRoot);
-  tryRunCmd('git restore --staged --worktree .', { cwd: repoRoot, timeoutMs: 60000 });
-  tryRunCmd('git reset --hard', { cwd: repoRoot, timeoutMs: 60000 });
+  tryRunCmd(['restore', '--staged', '--worktree', '.'], { cwd: repoRoot, timeoutMs: 60000 });
+  tryRunCmd(['reset', '--hard'], { cwd: repoRoot, timeoutMs: 60000 });
 }
 
 function rollbackNewUntrackedFiles({ repoRoot, baselineUntracked }) {

--- a/src/gep/idleScheduler.js
+++ b/src/gep/idleScheduler.js
@@ -5,7 +5,7 @@
 // When idle, the evolver can run more aggressive operations (distillation,
 // reflection); when busy, it only collects signals.
 
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -40,19 +40,19 @@ function getSystemIdleSeconds() {
       ].join('\n');
       const tmpPs = path.join(require('os').tmpdir(), 'evolver_idle_check.ps1');
       require('fs').writeFileSync(tmpPs, psCode, 'utf8');
-      const result = execSync('powershell -NoProfile -ExecutionPolicy Bypass -File "' + tmpPs + '"', { timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
+      const result = execFileSync('powershell', ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', tmpPs], { timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
       try { require('fs').unlinkSync(tmpPs); } catch (e) {}
       const seconds = parseInt(result, 10);
       return Number.isFinite(seconds) ? seconds : -1;
     } else if (platform === 'darwin') {
-      const result = execSync('ioreg -c IOHIDSystem | grep HIDIdleTime', { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
+      const result = execFileSync('ioreg', ['-c', 'IOHIDSystem'], { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
       const match = result.match(/(\d+)/);
       if (match) {
         return Math.floor(parseInt(match[1], 10) / 1000000000);
       }
     } else if (platform === 'linux') {
       try {
-        const result = execSync('xprintidle 2>/dev/null || echo -1', { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
+        const result = execFileSync('xprintidle', [], { timeout: 5000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER }).trim();
         const ms = parseInt(result, 10);
         if (Number.isFinite(ms) && ms >= 0) return Math.floor(ms / 1000);
       } catch (e) {}

--- a/src/gep/issueReporter.js
+++ b/src/gep/issueReporter.js
@@ -16,6 +16,12 @@ const DEFAULT_COOLDOWN_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_MIN_STREAK = 5;
 const MAX_LOG_CHARS = 2000;
 const MAX_EVENTS = 5;
+const PRIVATE_FILE_MODE = 0o600;
+
+function isIssueLogInclusionEnabled() {
+  const raw = String(process.env.EVOLVER_ISSUE_INCLUDE_LOGS || '').trim().toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on';
+}
 
 function getConfig() {
   const enabled = String(process.env.EVOLVER_AUTO_ISSUE || 'true').toLowerCase();
@@ -51,14 +57,28 @@ function writeState(state) {
   try {
     const dir = getEvolutionDir();
     if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-    fs.writeFileSync(getStatePath(), JSON.stringify(state, null, 2) + '\n');
+    const target = getStatePath();
+    const tmp = target + '.tmp';
+    fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
+    fs.renameSync(tmp, target);
+    try { fs.chmodSync(target, PRIVATE_FILE_MODE); } catch (_) {}
   } catch (_) {}
 }
 
-function truncateNodeId(nodeId) {
+function redactNodeId(nodeId) {
   if (!nodeId || typeof nodeId !== 'string') return 'unknown';
-  if (nodeId.length <= 10) return nodeId;
-  return nodeId.slice(0, 10) + '...';
+  return 'node:' + crypto.createHash('sha256').update(nodeId).digest('hex').slice(0, 12);
+}
+
+function selectSafeFingerprint(fp) {
+  const raw = fp && typeof fp === 'object' ? fp : {};
+  return {
+    evolver_version: raw.evolver_version || 'unknown',
+    node_version: raw.node_version || process.version,
+    platform: raw.platform || process.platform,
+    arch: raw.arch || process.arch,
+    container: !!raw.container,
+  };
 }
 
 function computeErrorKey(signals) {
@@ -102,8 +122,8 @@ function formatRecentEvents(events) {
   if (!Array.isArray(events) || events.length === 0) return '_No recent events available._';
   const failed = events.filter(function (e) { return e && e.outcome && e.outcome.status === 'failed'; });
   const rows = failed.slice(-MAX_EVENTS).map(function (e, idx) {
-    const intent = e.intent || '-';
-    const gene = (Array.isArray(e.genes_used) && e.genes_used[0]) || '-';
+    const intent = redactString(String(e.intent || '-')).slice(0, 80);
+    const gene = redactString(String((Array.isArray(e.genes_used) && e.genes_used[0]) || '-')).slice(0, 80);
     const outcome = (e.outcome && e.outcome.status) || '-';
     let reason = (e.outcome && e.outcome.reason) || '';
     if (reason.length > 80) reason = reason.slice(0, 80) + '...';
@@ -115,13 +135,13 @@ function formatRecentEvents(events) {
 }
 
 function buildIssueBody(opts) {
-  const fp = opts.envFingerprint || captureEnvFingerprint();
+  const fp = selectSafeFingerprint(opts.envFingerprint || captureEnvFingerprint());
   const signals = opts.signals || [];
   const recentEvents = opts.recentEvents || [];
   const sessionLog = opts.sessionLog || '';
   const streakCount = extractStreakCount(signals);
   const errorSig = extractErrorSignature(signals);
-  const nodeId = truncateNodeId(getNodeId());
+  const nodeId = redactNodeId(getNodeId());
 
   const failureSignals = signals.filter(function (s) {
     return s.startsWith('recurring_') ||
@@ -132,9 +152,9 @@ function buildIssueBody(opts) {
       s === 'force_innovation_after_repair_loop';
   }).join(', ');
 
-  const sanitizedLog = redactString(
-    typeof sessionLog === 'string' ? sessionLog.slice(-MAX_LOG_CHARS) : ''
-  );
+  const sanitizedLog = isIssueLogInclusionEnabled()
+    ? redactString(typeof sessionLog === 'string' ? sessionLog.slice(-MAX_LOG_CHARS) : '')
+    : '';
 
   const eventsTable = formatRecentEvents(recentEvents);
 
@@ -162,10 +182,10 @@ function buildIssueBody(opts) {
     eventsTable,
     '',
     '## Session Log Excerpt (sanitized)',
-    '```',
-    sanitizedLog || '_No session log available._',
-    '```',
-    '',
+    sanitizedLog ? '```' : '',
+    sanitizedLog || '_Log excerpt omitted by default. Set EVOLVER_ISSUE_INCLUDE_LOGS=true to include sanitized logs._',
+    sanitizedLog ? '```' : '',
+    sanitizedLog ? '' : '',
     '---',
     '_This issue was automatically created by evolver v' + (fp.evolver_version || 'unknown') + '._',
     '_Device: ' + nodeId + ' | Report ID: ' + reportId + '_',

--- a/src/gep/mailboxTransport.js
+++ b/src/gep/mailboxTransport.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const http = require('http');
-const { getProxyUrl } = require('../proxy/server/settings');
+const { getProxyUrl, getProxyRequestHeaders } = require('../proxy/server/settings');
 
 function _request(method, path, body) {
   const proxyUrl = getProxyUrl();
@@ -13,16 +13,17 @@ function _request(method, path, body) {
 
   return new Promise((resolve, reject) => {
     const payload = body ? JSON.stringify(body) : '';
+    const headers = Object.assign({
+      'Content-Type': 'application/json',
+      'Content-Length': Buffer.byteLength(payload),
+    }, getProxyRequestHeaders());
     const req = http.request(
       {
         hostname: url.hostname,
         port: url.port,
         path: url.pathname,
         method,
-        headers: {
-          'Content-Type': 'application/json',
-          'Content-Length': Buffer.byteLength(payload),
-        },
+        headers,
         timeout: 10_000,
       },
       (res) => {

--- a/src/gep/mailboxTransport.js
+++ b/src/gep/mailboxTransport.js
@@ -21,7 +21,7 @@ function _request(method, path, body) {
       {
         hostname: url.hostname,
         port: url.port,
-        path: url.pathname,
+        path: url.pathname + (url.search || ''),
         method,
         headers,
         timeout: 10_000,

--- a/src/gep/sanitize.js
+++ b/src/gep/sanitize.js
@@ -33,6 +33,9 @@ const REDACT_PATTERNS = [
   // Azure AD client secret + App Insights instrumentation key (value only)
   /client_secret=[A-Za-z0-9~._\-]{8,}/gi,
   /instrumentationkey=[0-9a-fA-F-]{20,}/gi,
+  // Node / app secrets persisted in config-like text
+  /(?:A2A_NODE_SECRET|node_secret|auth_token|_authToken)[=:]\s*["']?[A-Za-z0-9\-._~+\/]{16,}["']?/gi,
+  /(?:session|cookie)[_ -]?id[=:]\s*["']?[A-Za-z0-9\-._~+\/]{12,}["']?/gi,
   // Discord bot tokens. Three base64url segments:
   //   1. 24+ chars starting with [MNO] (user-id snowflake, base64-encoded)
   //   2. exactly 6 chars (timestamp)
@@ -44,6 +47,8 @@ const REDACT_PATTERNS = [
   /-----BEGIN\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----[\s\S]*?-----END\s+(?:RSA\s+|EC\s+|DSA\s+|OPENSSH\s+)?PRIVATE\s+KEY-----/g,
   // Basic auth in URLs (redact only credentials, keep :// and @)
   /(?<=:\/\/)[^@\s]+:[^@\s]+(?=@)/g,
+  // Database / broker URLs with embedded credentials
+  /(?:mongodb|postgres|postgresql|mysql|redis|amqp):\/\/[^\s"',;)}\]]{10,}/gi,
   // Local filesystem paths
   /\/home\/[^\s"',;)}\]]+/g,
   /\/Users\/[^\s"',;)}\]]+/g,
@@ -52,6 +57,10 @@ const REDACT_PATTERNS = [
   /[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/g,
   // .env file references
   /\.env(?:\.[a-zA-Z]+)?/g,
+  // Common dotfiles containing credentials
+  /\.(?:npmrc|pypirc|netrc|aws\/credentials|ssh\/config)\b/gi,
+  // Internal/private IP addresses
+  /\b(?:10\.\d{1,3}\.\d{1,3}\.\d{1,3}|172\.(?:1[6-9]|2\d|3[01])\.\d{1,3}\.\d{1,3}|192\.168\.\d{1,3}\.\d{1,3})(?::\d{2,5})?\b/g,
 ];
 
 const REDACTED = '[REDACTED]';

--- a/src/gep/selfPR.js
+++ b/src/gep/selfPR.js
@@ -9,7 +9,7 @@
 const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
-const { execSync } = require('child_process');
+const { execSync, execFileSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -206,7 +206,8 @@ function runGh(args, opts) {
   const timeoutMs = (opts && opts.timeoutMs) || SELF_PR_TIMEOUT_MS;
   const cwd = (opts && opts.cwd) || getRepoRoot();
   try {
-    const result = execSync('gh ' + args, {
+    const argv = Array.isArray(args) ? args : String(args || '').split(/\s+/).filter(Boolean);
+    const result = execFileSync('gh', argv, {
       cwd: cwd,
       timeout: timeoutMs,
       encoding: 'utf8',
@@ -224,16 +225,18 @@ function getGitDiff(changedFiles, repoRoot) {
   for (const f of changedFiles) {
     const before = parts.length;
     try {
-      const result = execSync(
-        'git diff HEAD -- "' + f + '"',
+      const result = execFileSync(
+        'git',
+        ['diff', 'HEAD', '--', f],
         { cwd: repoRoot, timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_EXEC_BUFFER }
       );
       if (result && result.trim()) parts.push(result.trim());
     } catch (_) {}
     if (parts.length === before) {
       try {
-        const result = execSync(
-          'git diff -- "' + f + '"',
+        const result = execFileSync(
+          'git',
+          ['diff', '--', f],
           { cwd: repoRoot, timeout: 10000, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_EXEC_BUFFER }
         );
         if (result && result.trim()) parts.push(result.trim());
@@ -300,7 +303,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
   try {
     console.log('[SelfPR] Creating PR on ' + repo + ' branch ' + branch + '...');
 
-    const forkCheck = runGh('repo view ' + repo + ' --json name', { timeoutMs: 15000 });
+    const forkCheck = runGh(['repo', 'view', repo, '--json', 'name'], { timeoutMs: 15000 });
     if (!forkCheck.ok) {
       console.warn('[SelfPR] Cannot access repo ' + repo + ': ' + (forkCheck.err || 'unknown'));
       return { attempted: false, reason: 'repo_access_failed' };
@@ -313,7 +316,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     fs.mkdirSync(tmpDir, { recursive: true });
 
     const cloneResult = runGh(
-      'repo clone ' + repo + ' "' + tmpDir + '" -- --depth 1',
+      ['repo', 'clone', repo, tmpDir, '--', '--depth', '1'],
       { timeoutMs: 60000 }
     );
     if (!cloneResult.ok) {
@@ -322,7 +325,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     }
 
     try {
-      execSync('git checkout -b "' + branch + '"', { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
+      execFileSync('git', ['checkout', '-b', branch], { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
     } catch (e) {
       console.warn('[SelfPR] Branch creation failed: ' + (e.message || e));
       return { attempted: false, reason: 'branch_failed' };
@@ -339,14 +342,15 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     }
 
     try {
-      execSync('git add -A', { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
-      const statusOut = execSync('git status --porcelain', { cwd: tmpDir, timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
+      execFileSync('git', ['add', '-A'], { cwd: tmpDir, timeout: 10000, maxBuffer: MAX_EXEC_BUFFER });
+      const statusOut = execFileSync('git', ['status', '--porcelain'], { cwd: tmpDir, timeout: 10000, encoding: 'utf8', maxBuffer: MAX_EXEC_BUFFER });
       if (!statusOut || !statusOut.trim()) {
         console.log('[SelfPR] No changes to commit in public repo clone.');
         return { attempted: false, reason: 'no_public_diff' };
       }
-      execSync(
-        'git commit -m "' + title.replace(/"/g, '\\"') + '"',
+      execFileSync(
+        'git',
+        ['commit', '-m', title],
         { cwd: tmpDir, timeout: 10000, env: Object.assign({}, process.env, { GIT_AUTHOR_NAME: 'evolver-bot', GIT_AUTHOR_EMAIL: 'evolver-bot@evomap.ai', GIT_COMMITTER_NAME: 'evolver-bot', GIT_COMMITTER_EMAIL: 'evolver-bot@evomap.ai' }) }
       );
     } catch (e) {
@@ -355,7 +359,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     }
 
     try {
-      execSync('git push origin "' + branch + '"', { cwd: tmpDir, timeout: 30000 });
+      execFileSync('git', ['push', 'origin', branch], { cwd: tmpDir, timeout: 30000 });
     } catch (e) {
       console.warn('[SelfPR] Push failed: ' + (e.message || e));
       return { attempted: false, reason: 'push_failed' };
@@ -365,11 +369,7 @@ async function maybeCreatePR({ capsule, event, mutation, gene, blastRadius }) {
     fs.writeFileSync(bodyFile, body);
 
     const prResult = runGh(
-      'pr create --repo ' + repo +
-      ' --head "' + branch + '"' +
-      ' --title "' + title.replace(/"/g, '\\"') + '"' +
-      ' --body-file "' + bodyFile + '"' +
-      ' --label "auto-mutation"',
+      ['pr', 'create', '--repo', repo, '--head', branch, '--title', title, '--body-file', bodyFile, '--label', 'auto-mutation'],
       { cwd: tmpDir, timeoutMs: 30000 }
     );
 

--- a/src/gep/validator/sandboxExecutor.js
+++ b/src/gep/validator/sandboxExecutor.js
@@ -74,6 +74,26 @@ function assertNodeCommandSafe(parsed) {
   }
 }
 
+function assertScriptPathSafe(parsed, cwd) {
+  if (parsed.executable !== 'node') return;
+  const firstPositional = parsed.args.find((a) => !a.startsWith('-'));
+  if (!firstPositional) {
+    throw new Error('missing_script_file');
+  }
+  if (path.isAbsolute(firstPositional)) {
+    throw new Error('absolute_script_path_not_allowed');
+  }
+  const resolvedCwd = path.resolve(String(cwd || '.'));
+  const resolvedScript = path.resolve(resolvedCwd, firstPositional);
+  const rel = path.relative(resolvedCwd, resolvedScript);
+  if (!rel || rel === '..' || rel.startsWith('..' + path.sep) || path.isAbsolute(rel)) {
+    throw new Error('script_path_escapes_sandbox');
+  }
+  if (!fs.existsSync(resolvedScript)) {
+    throw new Error('script_not_found_in_sandbox');
+  }
+}
+
 // Parse a command string into executable + argv array, supporting single and
 // double quotes. This is a minimal parser and does NOT expand environment
 // variables, globs, redirects, pipes, or subshells. If the command string
@@ -193,6 +213,7 @@ function runSingleCommand(cmd, opts) {
     try {
       parsed = parseCommand(String(cmd));
       assertNodeCommandSafe(parsed);
+      assertScriptPathSafe(parsed, cwd);
     } catch (err) {
       resolve({
         cmd: String(cmd),
@@ -390,6 +411,7 @@ module.exports = {
   buildSandboxEnv,
   parseCommand,
   assertNodeCommandSafe,
+  assertScriptPathSafe,
   ALLOWED_EXECUTABLES,
   BLOCKED_NODE_FLAGS,
   DEFAULT_CMD_TIMEOUT_MS,

--- a/src/ops/lifecycle.js
+++ b/src/ops/lifecycle.js
@@ -5,7 +5,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync, spawn } = require('child_process');
+const { execFileSync, spawn } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -34,13 +34,22 @@ function sleepMs(ms) {
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, delay);
 }
 
-function execText(command) {
-    return execSync(command, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: MAX_EXEC_BUFFER });
+function execText(file, args) {
+    return execFileSync(file, Array.isArray(args) ? args : [], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+        maxBuffer: MAX_EXEC_BUFFER,
+        windowsHide: true,
+    });
 }
 
 function listProcesses() {
     if (process.platform === 'win32') {
-        var out = execText('powershell -NoProfile -Command "Get-CimInstance Win32_Process | ForEach-Object { $cmd = if ($_.CommandLine) { $_.CommandLine } else { \'\' }; Write-Output (\'{0}\\t{1}\' -f $_.ProcessId, $cmd) }"');
+        var out = execText('powershell', [
+            '-NoProfile',
+            '-Command',
+            "Get-CimInstance Win32_Process | ForEach-Object { $cmd = if ($_.CommandLine) { $_.CommandLine } else { '' }; Write-Output ('{0}`t{1}' -f $_.ProcessId, $cmd) }",
+        ]);
         var procs = [];
         for (var line of out.split(/\r?\n/)) {
             if (!line || !line.trim()) continue;
@@ -52,7 +61,7 @@ function listProcesses() {
         }
         return procs;
     }
-    var psOut = execText('ps -e -o pid=,args=');
+    var psOut = execText('ps', ['-e', '-o', 'pid=,args=']);
     var unixProcs = [];
     for (var psLine of psOut.split('\n')) {
         var trimmed = psLine.trim();

--- a/src/ops/self_repair.js
+++ b/src/ops/self_repair.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 // 10 MB — prevents RangeError on large child process output (e.g. git log/diff
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
@@ -12,20 +12,29 @@ const { getWorkspaceRoot } = require('../gep/paths');
 
 var LOCK_MAX_AGE_MS = require('../config').LOCK_MAX_AGE_MS;
 
+function runGit(args, options) {
+    return execFileSync('git', Array.isArray(args) ? args : [], Object.assign({
+        encoding: 'utf8',
+        stdio: 'ignore',
+        maxBuffer: MAX_EXEC_BUFFER,
+        windowsHide: true,
+    }, options || {}));
+}
+
 function repair(gitRoot) {
     var root = gitRoot || getWorkspaceRoot();
     var repaired = [];
 
     // 1. Abort pending rebase
     try {
-        execSync('git rebase --abort', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
+        runGit(['rebase', '--abort'], { cwd: root });
         repaired.push('rebase_aborted');
         console.log('[SelfRepair] Aborted pending rebase.');
     } catch (e) {}
 
     // 2. Abort pending merge
     try {
-        execSync('git merge --abort', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
+        runGit(['merge', '--abort'], { cwd: root });
         repaired.push('merge_aborted');
         console.log('[SelfRepair] Aborted pending merge.');
     } catch (e) {}
@@ -48,9 +57,9 @@ function repair(gitRoot) {
     // Only enabled if explicitly called with --force-reset or EVOLVE_GIT_RESET=true
     if (process.env.EVOLVE_GIT_RESET === 'true') {
         try {
-            console.log('[SelfRepair] Resetting local branch to origin/main (HARD reset)...');
-            execSync('git fetch origin main', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
-            execSync('git reset --hard origin/main', { cwd: root, stdio: 'ignore', maxBuffer: MAX_EXEC_BUFFER });
+            console.warn('[SelfRepair] EVOLVE_GIT_RESET=true set. Resetting local branch to origin/main (HARD reset).');
+            runGit(['fetch', 'origin', 'main'], { cwd: root });
+            runGit(['reset', '--hard', 'origin/main'], { cwd: root });
             repaired.push('hard_reset_to_origin');
         } catch (e) {
             console.warn('[SelfRepair] Hard reset failed: ' + e.message);
@@ -58,7 +67,7 @@ function repair(gitRoot) {
     } else {
         // Safe fetch
         try {
-            execSync('git fetch origin', { cwd: root, stdio: 'ignore', timeout: 30000, maxBuffer: MAX_EXEC_BUFFER });
+            runGit(['fetch', 'origin'], { cwd: root, timeout: 30000 });
             repaired.push('fetch_ok');
         } catch (e) {
             console.warn('[SelfRepair] git fetch failed: ' + e.message);

--- a/src/ops/skills_monitor.js
+++ b/src/ops/skills_monitor.js
@@ -29,6 +29,9 @@ try {
     }
 } catch (e) { /* ignore */ }
 
+const ALLOW_AUTO_NPM_INSTALL =
+    String(process.env.EVOLVER_ENABLE_SKILL_AUTO_INSTALL || '').toLowerCase() === 'true';
+
 function checkSkill(skillName) {
     var SKILLS_DIR = getSkillsDir();
     if (IGNORE_LIST.has(skillName)) return null;
@@ -92,6 +95,10 @@ function autoHeal(skillName, issues) {
 
     for (var i = 0; i < issues.length; i++) {
         if (issues[i] === 'Missing node_modules (needs npm install)' || issues[i] === 'Empty node_modules (needs npm install)') {
+            if (!ALLOW_AUTO_NPM_INSTALL) {
+                console.warn('[SkillsMonitor] Auto npm install disabled for ' + skillName + '. Set EVOLVER_ENABLE_SKILL_AUTO_INSTALL=true to opt in.');
+                continue;
+            }
             try {
                 // Remove package-lock.json if it exists to prevent conflict errors
                 try { fs.unlinkSync(path.join(skillPath, 'package-lock.json')); } catch (e) {}

--- a/src/proxy/extensions/skillUpdater.js
+++ b/src/proxy/extensions/skillUpdater.js
@@ -5,9 +5,11 @@ const path = require('path');
 const crypto = require('crypto');
 
 const MAX_SKILL_UPDATE_BYTES = 512 * 1024;
+const ALLOW_UNSIGNED_SKILL_UPDATE =
+  String(process.env.EVOMAP_ALLOW_UNSIGNED_SKILL_UPDATE || '').toLowerCase() === 'true';
 
 function verifyPayloadHash(content, expectedHash) {
-  if (!expectedHash) return true;
+  if (!expectedHash) return ALLOW_UNSIGNED_SKILL_UPDATE;
   const actual = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
   return actual === String(expectedHash).toLowerCase();
 }
@@ -41,7 +43,7 @@ class SkillUpdater {
       return false;
     }
     if (!verifyPayloadHash(content, payload.sha256 || payload.content_sha256)) {
-      this.logger.warn('[skill-updater] skill_update hash mismatch');
+      this.logger.warn('[skill-updater] skill_update missing hash or hash mismatch');
       return false;
     }
 

--- a/src/proxy/extensions/skillUpdater.js
+++ b/src/proxy/extensions/skillUpdater.js
@@ -2,6 +2,15 @@
 
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+
+const MAX_SKILL_UPDATE_BYTES = 512 * 1024;
+
+function verifyPayloadHash(content, expectedHash) {
+  if (!expectedHash) return true;
+  const actual = crypto.createHash('sha256').update(content, 'utf8').digest('hex');
+  return actual === String(expectedHash).toLowerCase();
+}
 
 class SkillUpdater {
   constructor({ store, skillPath, logger } = {}) {
@@ -27,17 +36,28 @@ class SkillUpdater {
       this.logger.warn('[skill-updater] No content in skill_update message');
       return false;
     }
+    if (Buffer.byteLength(content, 'utf8') > MAX_SKILL_UPDATE_BYTES) {
+      this.logger.warn('[skill-updater] skill_update content too large');
+      return false;
+    }
+    if (!verifyPayloadHash(content, payload.sha256 || payload.content_sha256)) {
+      this.logger.warn('[skill-updater] skill_update hash mismatch');
+      return false;
+    }
 
     try {
       const dir = path.dirname(this.skillPath);
-      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 
       if (fs.existsSync(this.skillPath)) {
         const backupPath = this.skillPath + '.bak';
         fs.copyFileSync(this.skillPath, backupPath);
       }
 
-      fs.writeFileSync(this.skillPath, content, 'utf8');
+      const tmpPath = this.skillPath + '.tmp';
+      fs.writeFileSync(tmpPath, content, { encoding: 'utf8', mode: 0o600 });
+      fs.renameSync(tmpPath, this.skillPath);
+      try { fs.chmodSync(this.skillPath, 0o600); } catch {}
       this.store.setState('last_skill_update', new Date().toISOString());
       this.store.setState('skill_version', payload.version || 'unknown');
       this.logger.log(`[skill-updater] Updated skill.md (version: ${payload.version || 'unknown'})`);

--- a/src/proxy/mailbox/store.js
+++ b/src/proxy/mailbox/store.js
@@ -7,6 +7,8 @@ const crypto = require('crypto');
 const DEFAULT_CHANNEL = 'evomap-hub';
 const SCHEMA_VERSION = 1;
 const PROXY_PROTOCOL_VERSION = '0.1.0';
+const PRIVATE_FILE_MODE = 0o600;
+const PRIVATE_DIR_MODE = 0o700;
 
 // Merge `fields` into `target` while stripping keys that can mutate the
 // prototype chain. Mailbox rows are persisted as JSONL and rebuilt on
@@ -69,7 +71,10 @@ function safeParse(payload) {
 }
 
 function appendLine(filePath, obj) {
-  fs.appendFileSync(filePath, JSON.stringify(obj) + '\n', 'utf8');
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
+  fs.appendFileSync(filePath, JSON.stringify(obj) + '\n', { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
+  try { fs.chmodSync(filePath, PRIVATE_FILE_MODE); } catch {}
 }
 
 function readLines(filePath) {
@@ -90,7 +95,8 @@ function readLines(filePath) {
 class MailboxStore {
   constructor(dataDir) {
     if (!dataDir) throw new Error('dataDir is required');
-    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true });
+    if (!fs.existsSync(dataDir)) fs.mkdirSync(dataDir, { recursive: true, mode: PRIVATE_DIR_MODE });
+    try { fs.chmodSync(dataDir, PRIVATE_DIR_MODE); } catch {}
     this.dataDir = dataDir;
 
     this._messagesFile = path.join(dataDir, 'messages.jsonl');
@@ -134,10 +140,11 @@ class MailboxStore {
 
   _persistState() {
     const dir = path.dirname(this._stateFile);
-    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+    if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true, mode: PRIVATE_DIR_MODE });
     const tmp = `${this._stateFile}.tmp`;
-    fs.writeFileSync(tmp, JSON.stringify(this._state, null, 2) + '\n', 'utf8');
+    fs.writeFileSync(tmp, JSON.stringify(this._state, null, 2) + '\n', { encoding: 'utf8', mode: PRIVATE_FILE_MODE });
     fs.renameSync(tmp, this._stateFile);
+    try { fs.chmodSync(this._stateFile, PRIVATE_FILE_MODE); } catch {}
   }
 
   _rebuildIndex() {

--- a/src/proxy/mailbox/store.js
+++ b/src/proxy/mailbox/store.js
@@ -9,6 +9,12 @@ const SCHEMA_VERSION = 1;
 const PROXY_PROTOCOL_VERSION = '0.1.0';
 const PRIVATE_FILE_MODE = 0o600;
 const PRIVATE_DIR_MODE = 0o700;
+const MAX_MESSAGE_PAYLOAD_BYTES = Math.max(1024, Number(process.env.EVOMAP_MAILBOX_MAX_PAYLOAD_BYTES) || 256 * 1024);
+const MAX_BATCH_MESSAGES = Math.max(1, Number(process.env.EVOMAP_MAILBOX_MAX_BATCH_MESSAGES) || 100);
+const MAX_TYPE_LENGTH = 80;
+const MAX_CHANNEL_LENGTH = 80;
+const MAX_REF_ID_LENGTH = 200;
+const VALID_PRIORITIES = new Set(['high', 'normal', 'low']);
 
 // Merge `fields` into `target` while stripping keys that can mutate the
 // prototype chain. Mailbox rows are persisted as JSONL and rebuilt on
@@ -68,6 +74,51 @@ function safeParse(payload) {
   if (payload == null) return null;
   if (typeof payload !== 'string') return payload;
   try { return JSON.parse(payload); } catch { return payload; }
+}
+
+function payloadSizeBytes(payload) {
+  try {
+    return Buffer.byteLength(JSON.stringify(payload == null ? null : payload), 'utf8');
+  } catch (_) {
+    return MAX_MESSAGE_PAYLOAD_BYTES + 1;
+  }
+}
+
+function normalizeStringField(value, fallback, maxLength, fieldName) {
+  const out = value == null || value === '' ? fallback : String(value);
+  if (!out || !out.trim()) {
+    throw new Error(fieldName + ' is required');
+  }
+  if (out.length > maxLength) {
+    throw new Error(fieldName + ' exceeds max length');
+  }
+  return out;
+}
+
+function normalizePriority(priority) {
+  const out = priority == null || priority === '' ? 'normal' : String(priority).toLowerCase();
+  if (!VALID_PRIORITIES.has(out)) throw new Error('invalid priority');
+  return out;
+}
+
+function normalizePayload(payload) {
+  const parsed = safeParse(payload);
+  if (payloadSizeBytes(parsed) > MAX_MESSAGE_PAYLOAD_BYTES) {
+    throw new Error('payload exceeds max size');
+  }
+  return parsed;
+}
+
+function normalizeEnvelope(fields) {
+  const data = fields || {};
+  return {
+    type: normalizeStringField(data.type, null, MAX_TYPE_LENGTH, 'type'),
+    channel: normalizeStringField(data.channel, DEFAULT_CHANNEL, MAX_CHANNEL_LENGTH, 'channel'),
+    payload: normalizePayload(data.payload),
+    priority: normalizePriority(data.priority),
+    ref_id: data.refId == null || data.refId === '' ? null : normalizeStringField(data.refId, null, MAX_REF_ID_LENGTH, 'ref_id'),
+    expires_at: data.expiresAt || null,
+  };
 }
 
 function appendLine(filePath, obj) {
@@ -194,20 +245,21 @@ class MailboxStore {
   // --- Public API: send / writeInbound ---
 
   send({ type, payload, channel, priority, refId, expiresAt }) {
+    const envelope = normalizeEnvelope({ type, payload, channel, priority, refId, expiresAt });
     const id = generateUUIDv7();
     const now = Date.now();
     const msg = {
       id,
-      channel: channel || DEFAULT_CHANNEL,
+      channel: envelope.channel,
       direction: 'outbound',
-      type,
+      type: envelope.type,
       status: 'pending',
-      payload: safeParse(payload),
-      priority: priority || 'normal',
-      ref_id: refId || null,
+      payload: envelope.payload,
+      priority: envelope.priority,
+      ref_id: envelope.ref_id,
       created_at: now,
       synced_at: null,
-      expires_at: expiresAt || null,
+      expires_at: envelope.expires_at,
       retry_count: 0,
       error: null,
     };
@@ -216,6 +268,7 @@ class MailboxStore {
   }
 
   writeInbound({ id, type, payload, channel, priority, refId, expiresAt }) {
+    const envelope = normalizeEnvelope({ type, payload, channel, priority, refId, expiresAt });
     const msgId = id || generateUUIDv7();
     // At-least-once delivery from the Hub / retry loops can send the same
     // message id twice. Without idempotency, poll() and countPending() would
@@ -225,16 +278,16 @@ class MailboxStore {
     const now = Date.now();
     const msg = {
       id: msgId,
-      channel: channel || DEFAULT_CHANNEL,
+      channel: envelope.channel,
       direction: 'inbound',
-      type,
+      type: envelope.type,
       status: 'pending',
-      payload: safeParse(payload),
-      priority: priority || 'normal',
-      ref_id: refId || null,
+      payload: envelope.payload,
+      priority: envelope.priority,
+      ref_id: envelope.ref_id,
       created_at: now,
       synced_at: null,
-      expires_at: expiresAt || null,
+      expires_at: envelope.expires_at,
       retry_count: 0,
       error: null,
     };
@@ -243,6 +296,8 @@ class MailboxStore {
   }
 
   writeInboundBatch(messages) {
+    if (!Array.isArray(messages)) throw new Error('messages must be an array');
+    if (messages.length > MAX_BATCH_MESSAGES) throw new Error('batch exceeds max message count');
     const ids = [];
     for (const m of messages) {
       ids.push(this.writeInbound(m));

--- a/src/proxy/server/http.js
+++ b/src/proxy/server/http.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const http = require('http');
-const { writeSettings, readSettings, clearSettings, clearIfStale } = require('./settings');
+const { writeSettings, clearSettings, clearIfStale, createProxyAuthToken } = require('./settings');
 
 const MAX_PORT_ATTEMPTS = 100;
 const DEFAULT_PORT = 19820;
@@ -89,6 +89,8 @@ class ProxyHttpServer {
     this.actualPort = null;
     this.logger = logger || console;
     this.server = null;
+    this.requireAuth = String(process.env.EVOMAP_PROXY_REQUIRE_AUTH || 'true').toLowerCase() !== 'false';
+    this.authToken = createProxyAuthToken();
   }
 
   async start() {
@@ -106,6 +108,7 @@ class ProxyHttpServer {
             url,
             pid: process.pid,
             started_at: new Date().toISOString(),
+            auth_token: this.authToken,
           },
         });
         this.logger.log(`[proxy] HTTP server listening on ${url}`);
@@ -127,6 +130,13 @@ class ProxyHttpServer {
   async _handleRequest(req, res) {
     const url = new URL(req.url, `http://127.0.0.1:${this.actualPort}`);
     const routeKey = `${req.method} ${url.pathname}`;
+
+    if (this.requireAuth) {
+      const provided = req.headers['x-evomap-proxy-token'];
+      if (!provided || provided !== this.authToken) {
+        return sendJson(res, 401, { error: 'Unauthorized' });
+      }
+    }
 
     const paramMatch = this._matchRoute(req.method, url.pathname);
 

--- a/src/proxy/server/settings.js
+++ b/src/proxy/server/settings.js
@@ -5,31 +5,43 @@ const path = require('path');
 const os = require('os');
 const crypto = require('crypto');
 
-const SETTINGS_DIR = path.join(os.homedir(), '.evolver');
-const SETTINGS_FILE = path.join(SETTINGS_DIR, 'settings.json');
+const DEFAULT_SETTINGS_DIR = path.join(os.homedir(), '.evolver');
+const SETTINGS_DIR = DEFAULT_SETTINGS_DIR;
+const SETTINGS_FILE = path.join(DEFAULT_SETTINGS_DIR, 'settings.json');
 const FILE_MODE = 0o600;
 const DIR_MODE = 0o700;
 
+function resolveSettingsDir() {
+  return process.env.EVOLVER_SETTINGS_DIR || DEFAULT_SETTINGS_DIR;
+}
+
+function resolveSettingsFile() {
+  return path.join(resolveSettingsDir(), 'settings.json');
+}
+
 function ensureSettingsDir() {
-  if (!fs.existsSync(SETTINGS_DIR)) {
-    fs.mkdirSync(SETTINGS_DIR, { recursive: true, mode: DIR_MODE });
+  const settingsDir = resolveSettingsDir();
+  if (!fs.existsSync(settingsDir)) {
+    fs.mkdirSync(settingsDir, { recursive: true, mode: DIR_MODE });
     return;
   }
-  try { fs.chmodSync(SETTINGS_DIR, DIR_MODE); } catch {}
+  try { fs.chmodSync(settingsDir, DIR_MODE); } catch {}
 }
 
 function writeSettingsFile(data) {
   ensureSettingsDir();
-  const tmp = SETTINGS_FILE + '.tmp';
+  const settingsFile = resolveSettingsFile();
+  const tmp = settingsFile + '.tmp';
   fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { encoding: 'utf8', mode: FILE_MODE });
-  fs.renameSync(tmp, SETTINGS_FILE);
-  try { fs.chmodSync(SETTINGS_FILE, FILE_MODE); } catch {}
+  fs.renameSync(tmp, settingsFile);
+  try { fs.chmodSync(settingsFile, FILE_MODE); } catch {}
 }
 
 function readSettings() {
   try {
-    if (fs.existsSync(SETTINGS_FILE)) {
-      return JSON.parse(fs.readFileSync(SETTINGS_FILE, 'utf8'));
+    const settingsFile = resolveSettingsFile();
+    if (fs.existsSync(settingsFile)) {
+      return JSON.parse(fs.readFileSync(settingsFile, 'utf8'));
     }
   } catch {}
   return {};
@@ -44,7 +56,8 @@ function writeSettings(data) {
 
 function clearSettings() {
   try {
-    if (fs.existsSync(SETTINGS_FILE)) {
+    const settingsFile = resolveSettingsFile();
+    if (fs.existsSync(settingsFile)) {
       const current = readSettings();
       delete current.proxy;
       writeSettingsFile(current);
@@ -102,6 +115,8 @@ module.exports = {
   getProxyAuthToken,
   getProxyRequestHeaders,
   createProxyAuthToken,
+  resolveSettingsDir,
+  resolveSettingsFile,
   SETTINGS_DIR,
   SETTINGS_FILE,
 };

--- a/src/proxy/server/settings.js
+++ b/src/proxy/server/settings.js
@@ -3,9 +3,28 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const crypto = require('crypto');
 
 const SETTINGS_DIR = path.join(os.homedir(), '.evolver');
 const SETTINGS_FILE = path.join(SETTINGS_DIR, 'settings.json');
+const FILE_MODE = 0o600;
+const DIR_MODE = 0o700;
+
+function ensureSettingsDir() {
+  if (!fs.existsSync(SETTINGS_DIR)) {
+    fs.mkdirSync(SETTINGS_DIR, { recursive: true, mode: DIR_MODE });
+    return;
+  }
+  try { fs.chmodSync(SETTINGS_DIR, DIR_MODE); } catch {}
+}
+
+function writeSettingsFile(data) {
+  ensureSettingsDir();
+  const tmp = SETTINGS_FILE + '.tmp';
+  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', { encoding: 'utf8', mode: FILE_MODE });
+  fs.renameSync(tmp, SETTINGS_FILE);
+  try { fs.chmodSync(SETTINGS_FILE, FILE_MODE); } catch {}
+}
 
 function readSettings() {
   try {
@@ -17,12 +36,9 @@ function readSettings() {
 }
 
 function writeSettings(data) {
-  if (!fs.existsSync(SETTINGS_DIR)) {
-    fs.mkdirSync(SETTINGS_DIR, { recursive: true });
-  }
   const current = readSettings();
   const merged = { ...current, ...data };
-  fs.writeFileSync(SETTINGS_FILE, JSON.stringify(merged, null, 2), 'utf8');
+  writeSettingsFile(merged);
   return merged;
 }
 
@@ -31,7 +47,7 @@ function clearSettings() {
     if (fs.existsSync(SETTINGS_FILE)) {
       const current = readSettings();
       delete current.proxy;
-      fs.writeFileSync(SETTINGS_FILE, JSON.stringify(current, null, 2), 'utf8');
+      writeSettingsFile(current);
     }
   } catch {}
 }
@@ -61,4 +77,31 @@ function getProxyUrl() {
   return settings.proxy?.url || null;
 }
 
-module.exports = { readSettings, writeSettings, clearSettings, clearIfStale, isStaleProxy, getProxyUrl, SETTINGS_DIR, SETTINGS_FILE };
+function getProxyAuthToken() {
+  const settings = readSettings();
+  return settings.proxy?.auth_token || null;
+}
+
+function getProxyRequestHeaders() {
+  const token = getProxyAuthToken();
+  if (!token) return {};
+  return { 'x-evomap-proxy-token': token };
+}
+
+function createProxyAuthToken() {
+  return crypto.randomBytes(24).toString('hex');
+}
+
+module.exports = {
+  readSettings,
+  writeSettings,
+  clearSettings,
+  clearIfStale,
+  isStaleProxy,
+  getProxyUrl,
+  getProxyAuthToken,
+  getProxyRequestHeaders,
+  createProxyAuthToken,
+  SETTINGS_DIR,
+  SETTINGS_FILE,
+};

--- a/test/atpAutoDeliver.test.js
+++ b/test/atpAutoDeliver.test.js
@@ -169,12 +169,14 @@ describe('autoDeliver.buildProofPayload', () => {
     const p = autoDeliver.__internals.buildProofPayload({
       result_asset_id: 'asset_xyz',
       claimed_at: '2026-04-27T00:00:00.000Z',
-      signals: ['s1'],
+      signals: ['s1', 'token=abcdefghijklmnop1234567890', 'path:/home/alice/private'],
     });
     assert.equal(p.result, 'completed');
     assert.equal(p.asset_id, 'asset_xyz');
     assert.equal(p.pass_rate, 1.0);
     assert.equal(p.submitter, 'evolver_auto_deliver');
-    assert.deepEqual(p.signals, ['s1']);
+    assert.equal(p.signals[0], 's1');
+    assert.ok(p.signals[1].includes('[REDACTED]'));
+    assert.ok(p.signals[2].includes('[REDACTED]'));
   });
 });

--- a/test/atpExecute.test.js
+++ b/test/atpExecute.test.js
@@ -32,6 +32,15 @@ describe('atpExecute._buildGene', () => {
     const g = _buildGene(manyCaps, manySigs);
     assert.ok(g.signals_match.length <= 8, 'signals_match should be clamped');
   });
+
+  it('sanitizes capability and signal metadata', () => {
+    const g = _buildGene(
+      ['code_evolution', 'A2A_NODE_SECRET=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'],
+      ['task_for /home/alice/private']
+    );
+    assert.ok(!g.id.includes('A2A_NODE_SECRET'));
+    assert.ok(g.signals_match[0].includes('[REDACTED]'));
+  });
 });
 
 describe('atpExecute._buildCapsule', () => {
@@ -53,6 +62,19 @@ describe('atpExecute._buildCapsule', () => {
     assert.equal(capsule.atp.order_id, 'proof_abc123');
     assert.equal(capsule.atp.task_id, 'task_xyz789');
     assert.ok(capsule.asset_id.startsWith('sha256:'));
+  });
+
+  it('redacts secrets and local paths from capsule content and summary', () => {
+    const gene = _buildGene(['general'], []);
+    const capsule = _buildCapsule({
+      gene: gene,
+      answer: 'token=abcdefghijklmnop1234567890 and /home/alice/private',
+      summary: 'A2A_NODE_SECRET=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+      orderId: 'proof_secret',
+    });
+    assert.ok(capsule.content.includes('[REDACTED]'));
+    assert.ok(!capsule.content.includes('/home/alice/private'));
+    assert.ok(capsule.summary.includes('[REDACTED]'));
   });
 
   it('defaults capsule summary when caller does not provide one', () => {

--- a/test/atpHeartbeatSignalsHandler.test.js
+++ b/test/atpHeartbeatSignalsHandler.test.js
@@ -67,6 +67,18 @@ describe('heartbeatSignalsHandler gating', () => {
     assert.equal(submitCalls[0].payload.result, 'completed');
   });
 
+  it('writes heartbeat ledger with private permissions when possible', async () => {
+    const signals = {
+      pending_deliveries: [
+        { proof_id: 'p1', order_id: 'atp_perm', task_id: 't1', result_asset_id: 'asset1', verify_mode: 'auto' },
+      ],
+    };
+    const summary = await handler.handleHeartbeatSignals(signals);
+    assert.equal(summary.submitted, 1);
+    const ledgerPath = path.join(tmpMemoryDir, 'atp-autodeliver-ledger.json');
+    assert.ok(fs.existsSync(ledgerPath));
+  });
+
   it('skips deliveries without result_asset_id (nothing to deliver)', async () => {
     const signals = {
       pending_deliveries: [

--- a/test/extensions.test.js
+++ b/test/extensions.test.js
@@ -30,6 +30,14 @@ describe('SkillUpdater', () => {
     try { fs.rmSync(skillDir, { recursive: true }); } catch {}
   });
 
+  function withHash(content, version) {
+    return {
+      content,
+      version,
+      sha256: require('crypto').createHash('sha256').update(content, 'utf8').digest('hex'),
+    };
+  }
+
   it('updates skill.md from inbound message', () => {
     const skillPath = path.join(skillDir, 'SKILL.md');
     const updater = new SkillUpdater({
@@ -39,7 +47,7 @@ describe('SkillUpdater', () => {
     });
 
     const result = updater.processSkillUpdate({
-      payload: { content: '# Updated Skill\nNew content here.', version: '1.1.0' },
+      payload: withHash('# Updated Skill\nNew content here.', '1.1.0'),
     });
     assert.equal(result, true);
     assert.equal(fs.readFileSync(skillPath, 'utf8'), '# Updated Skill\nNew content here.');
@@ -57,7 +65,7 @@ describe('SkillUpdater', () => {
     });
 
     updater.processSkillUpdate({
-      payload: { content: 'updated content', version: '2.0' },
+      payload: withHash('updated content', '2.0'),
     });
     assert.equal(fs.readFileSync(skillPath, 'utf8'), 'updated content');
     assert.equal(fs.readFileSync(skillPath + '.bak', 'utf8'), 'original content');
@@ -80,6 +88,18 @@ describe('SkillUpdater', () => {
     assert.equal(updater.processSkillUpdate({ payload: {} }), false);
   });
 
+  it('returns false without a payload hash by default', () => {
+    const updater = new SkillUpdater({
+      store,
+      skillPath: path.join(skillDir, 'unsigned.md'),
+      logger: { log: () => {}, warn: () => {}, error: () => {} },
+    });
+    assert.equal(
+      updater.processSkillUpdate({ payload: { content: 'unsigned content', version: '0.1.0' } }),
+      false,
+    );
+  });
+
   it('pollAndApply processes pending skill_update messages', () => {
     const dir2 = tmpDataDir();
     const s2 = new MailboxStore(dir2);
@@ -87,7 +107,7 @@ describe('SkillUpdater', () => {
 
     s2.writeInbound({
       type: 'skill_update',
-      payload: { content: '# Polled skill', version: '3.0' },
+      payload: withHash('# Polled skill', '3.0'),
     });
 
     const updater = new SkillUpdater({

--- a/test/featureFlags.test.js
+++ b/test/featureFlags.test.js
@@ -35,6 +35,7 @@ describe('featureFlags persistence', function () {
   });
 
   it('persists value across cache resets', function () {
+    process.env.EVOLVER_ENABLE_HUB_FEATURE_FLAGS = 'true';
     const ff = freshRequire('../src/gep/featureFlags');
     assert.equal(ff.writeFeatureFlag('validator_enabled', true, 'hub_mailbox'), true);
 
@@ -83,6 +84,7 @@ describe('isValidatorEnabled three-tier resolution', function () {
   });
 
   it('env=0 wins over persisted flag=true', function () {
+    process.env.EVOLVER_ENABLE_HUB_FEATURE_FLAGS = 'true';
     const ff = freshRequire('../src/gep/featureFlags');
     ff.writeFeatureFlag('validator_enabled', true, 'hub_mailbox');
     process.env.EVOLVER_VALIDATOR_ENABLED = '0';
@@ -91,6 +93,7 @@ describe('isValidatorEnabled three-tier resolution', function () {
   });
 
   it('env=1 wins over persisted flag=false', function () {
+    process.env.EVOLVER_ENABLE_HUB_FEATURE_FLAGS = 'true';
     const ff = freshRequire('../src/gep/featureFlags');
     ff.writeFeatureFlag('validator_enabled', false, 'hub_mailbox');
     process.env.EVOLVER_VALIDATOR_ENABLED = '1';
@@ -99,10 +102,23 @@ describe('isValidatorEnabled three-tier resolution', function () {
   });
 
   it('persisted flag=false applied when env unset', function () {
+    process.env.EVOLVER_ENABLE_HUB_FEATURE_FLAGS = 'true';
     const ff = freshRequire('../src/gep/featureFlags');
     ff.writeFeatureFlag('validator_enabled', false, 'hub_mailbox');
     const v = freshRequire('../src/gep/validator');
     assert.equal(v.isValidatorEnabled(), false);
+  });
+
+  it('rejects hub-sourced updates unless explicitly enabled', function () {
+    const ff = freshRequire('../src/gep/featureFlags');
+    assert.equal(ff.writeFeatureFlag('validator_enabled', false, 'hub_mailbox'), false);
+    assert.equal(ff.readFeatureFlag('validator_enabled'), undefined);
+  });
+
+  it('rejects unknown keys and invalid value types', function () {
+    const ff = freshRequire('../src/gep/featureFlags');
+    assert.equal(ff.writeFeatureFlag('unexpected_flag', true, 'manual'), false);
+    assert.equal(ff.writeFeatureFlag('validator_enabled', 'true', 'manual'), false);
   });
 
   it('accepts off/false/no aliases for env opt-out', function () {

--- a/test/issueReporter.test.js
+++ b/test/issueReporter.test.js
@@ -19,7 +19,7 @@ function jsonResponse(body, status) {
 
 (async function run() {
   delete require.cache[MODULE_PATH];
-  const { findExistingIssue } = require('../src/gep/issueReporter');
+  const { findExistingIssue, buildIssueBody } = require('../src/gep/issueReporter');
 
   // Case 1: search returns matching open issue -> returns object
   await withFetchMock(async function (url, opts) {
@@ -139,6 +139,42 @@ function jsonResponse(body, status) {
     const result = await findExistingIssue('x/y', target, 'faketoken');
     assert.strictEqual(result, null, 'substring fallback must not match unrelated titles');
   });
+
+  // Case D: buildIssueBody hashes node id and omits logs unless explicitly enabled
+  const savedNodeId = process.env.A2A_NODE_ID;
+  const savedIssueLogs = process.env.EVOLVER_ISSUE_INCLUDE_LOGS;
+  process.env.A2A_NODE_ID = 'node_super_sensitive_identifier_123456';
+  delete process.env.EVOLVER_ISSUE_INCLUDE_LOGS;
+  try {
+    const body = buildIssueBody({
+      envFingerprint: {
+        evolver_version: '1.0.0',
+        node_version: 'v20.0.0',
+        platform: 'linux',
+        arch: 'x64',
+        hostname: 'private-hostname',
+        cwd: '/home/alice/private',
+      },
+      signals: ['failure_loop_detected', 'consecutive_failure_streak_7'],
+      recentEvents: [{
+        intent: 'repair /home/alice/private',
+        genes_used: ['gene_private'],
+        outcome: { status: 'failed', reason: 'token=secretvalue1234567890' },
+      }],
+      sessionLog: 'A2A_NODE_SECRET=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789',
+    });
+    assert.ok(body.includes('node:'), 'body should contain redacted node id');
+    assert.ok(!body.includes('node_super_sensitive_identifier_123456'), 'raw node id must not be included');
+    assert.ok(!body.includes('private-hostname'), 'raw hostname must not be included');
+    assert.ok(!body.includes('/home/alice/private'), 'local path should be redacted');
+    assert.ok(body.includes('_Log excerpt omitted by default.'), 'logs should be omitted by default');
+    assert.ok(!body.includes('A2A_NODE_SECRET='), 'secret should not appear in body');
+  } finally {
+    if (savedNodeId === undefined) delete process.env.A2A_NODE_ID;
+    else process.env.A2A_NODE_ID = savedNodeId;
+    if (savedIssueLogs === undefined) delete process.env.EVOLVER_ISSUE_INCLUDE_LOGS;
+    else process.env.EVOLVER_ISSUE_INCLUDE_LOGS = savedIssueLogs;
+  }
 
   console.log('issueReporter.test.js: OK');
 })().catch(function (err) {

--- a/test/mailboxStore.test.js
+++ b/test/mailboxStore.test.js
@@ -81,6 +81,18 @@ describe('MailboxStore', () => {
       const msg = store.getById(result.message_id);
       assert.deepEqual(msg.payload, { raw: true });
     });
+
+    it('rejects oversized payloads and invalid priorities', () => {
+      assert.throws(() => store.send({
+        type: 'too_big',
+        payload: { blob: 'x'.repeat(300 * 1024) },
+      }), /payload exceeds max size/);
+      assert.throws(() => store.send({
+        type: 'bad_priority',
+        payload: {},
+        priority: 'urgent',
+      }), /invalid priority/);
+    });
   });
 
   describe('writeInbound()', () => {
@@ -128,6 +140,14 @@ describe('MailboxStore', () => {
         assert.ok(msg);
         assert.equal(msg.direction, 'inbound');
       }
+    });
+
+    it('rejects oversized batches', () => {
+      const batch = [];
+      for (let i = 0; i < 101; i++) {
+        batch.push({ type: 'dm', payload: { i } });
+      }
+      assert.throws(() => store.writeInboundBatch(batch), /batch exceeds max message count/);
     });
   });
 

--- a/test/proxyServer.test.js
+++ b/test/proxyServer.test.js
@@ -15,7 +15,9 @@ function tmpDataDir() {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'proxy-test-'));
 }
 
-function request(url, method, body) {
+let defaultHeaders = {};
+
+function request(url, method, body, headers) {
   return new Promise((resolve, reject) => {
     const u = new URL(url);
     const payload = body ? JSON.stringify(body) : '';
@@ -24,10 +26,10 @@ function request(url, method, body) {
       port: u.port,
       path: u.pathname + u.search,
       method,
-      headers: {
+      headers: Object.assign({
         'Content-Type': 'application/json',
         'Content-Length': Buffer.byteLength(payload),
-      },
+      }, defaultHeaders, headers || {}),
     }, (res) => {
       const chunks = [];
       res.on('data', c => chunks.push(c));
@@ -44,10 +46,12 @@ function request(url, method, body) {
 }
 
 describe('ProxyHttpServer', () => {
-  let store, server, baseUrl, dataDir;
+  let store, server, baseUrl, dataDir, settingsDir;
 
   before(async () => {
     dataDir = tmpDataDir();
+    settingsDir = tmpDataDir();
+    process.env.EVOLVER_SETTINGS_DIR = settingsDir;
     store = new MailboxStore(dataDir);
 
     const mockProxyHandlers = {
@@ -61,12 +65,24 @@ describe('ProxyHttpServer', () => {
     server = new ProxyHttpServer(routes, { port: 39820, logger: { log: () => {}, error: () => {}, warn: () => {} } });
     const info = await server.start();
     baseUrl = info.url;
+    defaultHeaders = { 'x-evomap-proxy-token': server.authToken };
   });
 
   after(async () => {
+    defaultHeaders = {};
     await server.stop();
     store.close();
+    delete process.env.EVOLVER_SETTINGS_DIR;
     try { fs.rmSync(dataDir, { recursive: true }); } catch {}
+    try { fs.rmSync(settingsDir, { recursive: true }); } catch {}
+  });
+
+  it('rejects requests without proxy auth token', async () => {
+    const res = await request(`${baseUrl}/mailbox/list?type=test`, 'GET', null, {
+      'x-evomap-proxy-token': '',
+    });
+    assert.equal(res.status, 401);
+    assert.equal(res.body.error, 'Unauthorized');
   });
 
   describe('POST /mailbox/send', () => {

--- a/test/sandboxExecutor.security.test.js
+++ b/test/sandboxExecutor.security.test.js
@@ -5,8 +5,17 @@
 
 const test = require('node:test');
 const assert = require('node:assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
-const { parseCommand, assertNodeCommandSafe, ALLOWED_EXECUTABLES, BLOCKED_NODE_FLAGS } = require('../src/gep/validator/sandboxExecutor');
+const {
+  parseCommand,
+  assertNodeCommandSafe,
+  assertScriptPathSafe,
+  ALLOWED_EXECUTABLES,
+  BLOCKED_NODE_FLAGS,
+} = require('../src/gep/validator/sandboxExecutor');
 
 test('parseCommand splits a simple command', () => {
   const r = parseCommand('node index.js');
@@ -123,4 +132,39 @@ test('assertNodeCommandSafe accepts well-formed node invocations', () => {
   assert.doesNotThrow(() => assertNodeCommandSafe({ executable: 'node', args: ['index.js'] }));
   assert.doesNotThrow(() => assertNodeCommandSafe({ executable: 'node', args: ['--no-warnings', 'index.js'] }));
   assert.doesNotThrow(() => assertNodeCommandSafe({ executable: 'node', args: ['scripts/validate-suite.js', '--quiet'] }));
+});
+
+test('assertScriptPathSafe rejects absolute and escaping paths', () => {
+  const sandboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-executor-test-'));
+  try {
+    const inSandbox = path.join(sandboxDir, 'ok.js');
+    fs.writeFileSync(inSandbox, 'console.log("ok")\n', 'utf8');
+    assert.doesNotThrow(() => assertScriptPathSafe({ executable: 'node', args: ['ok.js'] }, sandboxDir));
+
+    const parentEscape = path.join('..', 'escape.js');
+    assert.throws(
+      () => assertScriptPathSafe({ executable: 'node', args: [parentEscape] }, sandboxDir),
+      /escapes_sandbox/,
+    );
+
+    const absolute = path.resolve(sandboxDir, 'ok.js');
+    assert.throws(
+      () => assertScriptPathSafe({ executable: 'node', args: [absolute] }, sandboxDir),
+      /absolute_script_path_not_allowed/,
+    );
+  } finally {
+    try { fs.rmSync(sandboxDir, { recursive: true, force: true }); } catch {}
+  }
+});
+
+test('assertScriptPathSafe rejects missing script files', () => {
+  const sandboxDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sandbox-executor-test-'));
+  try {
+    assert.throws(
+      () => assertScriptPathSafe({ executable: 'node', args: ['missing.js'] }, sandboxDir),
+      /script_not_found_in_sandbox/,
+    );
+  } finally {
+    try { fs.rmSync(sandboxDir, { recursive: true, force: true }); } catch {}
+  }
 });

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -82,6 +82,14 @@ assert.ok(redactString('client_secret=aB3~cD4.eF5_gH6-iJ7').includes(REDACTED),
 // Application Insights instrumentation key
 assert.ok(redactString('InstrumentationKey=12345678-1234-1234-1234-1234567890ab').includes(REDACTED),
   'Azure instrumentationkey should be redacted');
+assert.ok(redactString('A2A_NODE_SECRET=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789').includes(REDACTED),
+  'node secret should be redacted');
+assert.ok(redactString('auth_token=abcdefghijklmnop1234567890').includes(REDACTED),
+  'auth token should be redacted');
+assert.ok(redactString('postgres://user:pass123@db.internal:5432/app').includes(REDACTED),
+  'database URL with credentials should be redacted');
+assert.ok(redactString('connect to 192.168.1.25:8080').includes(REDACTED),
+  'private IP should be redacted');
 
 // Discord bot token (uppercase leading char, three segments).
 // The sample is split and joined at runtime so static secret scanners do not
@@ -125,4 +133,4 @@ assert.strictEqual(sanitizePayload(undefined), undefined);
 assert.strictEqual(redactString(null), null);
 assert.strictEqual(redactString(123), 123);
 
-console.log('All sanitize tests passed (42 assertions)');
+console.log('All sanitize tests passed (46 assertions)');

--- a/test/serviceHelper.test.js
+++ b/test/serviceHelper.test.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  sanitizeServicePayload,
+  sanitizeServiceUpdates,
+} = require('../src/atp/serviceHelper');
+
+describe('serviceHelper sanitization', () => {
+  it('sanitizes and clamps publish payload fields', () => {
+    const payload = sanitizeServicePayload({
+      title: 'Code Review /home/alice/private',
+      description: 'token=abcdefghijklmnop1234567890',
+      capabilities: ['debugging', 'A2A_NODE_SECRET=abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789'],
+      useCases: ['investigate 192.168.1.25:8080'],
+      pricePerTask: 0,
+      executionMode: 'weird-mode',
+      maxConcurrent: 999,
+      recipeId: 'recipe-secret-token=abcdefghijklmnop1234567890',
+    });
+
+    assert.ok(payload.title.includes('[REDACTED]'));
+    assert.ok(payload.description.includes('[REDACTED]'));
+    assert.ok(payload.capabilities[1].includes('[REDACTED]'));
+    assert.ok(payload.use_cases[0].includes('[REDACTED]'));
+    assert.equal(payload.price_per_task, 1);
+    assert.equal(payload.execution_mode, 'exclusive');
+    assert.equal(payload.max_concurrent, 50);
+  });
+
+  it('sanitizes update payload fields', () => {
+    const updates = sanitizeServiceUpdates({
+      title: 'New title /home/bob/private',
+      description: 'postgres://user:pass123@db.internal:5432/app',
+      executionMode: 'open',
+      maxConcurrent: -5,
+    });
+
+    assert.ok(updates.title.includes('[REDACTED]'));
+    assert.ok(updates.description.includes('[REDACTED]'));
+    assert.equal(updates.execution_mode, 'open');
+    assert.equal(updates.max_concurrent, 1);
+  });
+});


### PR DESCRIPTION
## Summary

This PR is a second security hardening pass built on top of the previous proxy/sandbox/update-path hardening work.

It focuses on reducing trust in remote-controlled state, limiting local mailbox abuse, minimizing data egress, and sanitizing ATP publish/delivery payloads.

## Main changes

### Feature flag trust hardening
- restrict persisted feature flags to an explicit allowlist
- validate feature flag value types before writing
- ignore Hub-sourced feature flag updates by default
- require `EVOLVER_ENABLE_HUB_FEATURE_FLAGS=true` to accept Hub-pushed feature flags

Files:
- `src/gep/featureFlags.js`
- `test/featureFlags.test.js`
- `README.md`
- `SECURITY.md`

### Mailbox abuse limits
- add mailbox payload size limit
- add inbound batch size limit
- validate mailbox envelope fields:
  - `type`
  - `channel`
  - `ref_id`
  - `priority`
- restrict priority to `high`, `normal`, or `low`

Files:
- `src/proxy/mailbox/store.js`
- `test/mailboxStore.test.js`

### Data egress reduction
- expand redaction coverage for:
  - `A2A_NODE_SECRET`
  - `node_secret`
  - `auth_token`
  - session/cookie ids
  - database/broker URLs
  - private IPs
  - sensitive dotfiles
- hash node id in auto-created issue reports instead of including the raw id
- include only a safe subset of environment fingerprint data in issue reports
- omit session log excerpts by default
- require `EVOLVER_ISSUE_INCLUDE_LOGS=true` to include sanitized log excerpts
- write issue reporter state with tighter permissions

Files:
- `src/gep/sanitize.js`
- `src/gep/issueReporter.js`
- `test/sanitize.test.js`
- `test/issueReporter.test.js`
- `README.md`
- `SECURITY.md`

### ATP publish path sanitization
- sanitize ATP answer content before publishing it as Capsule content
- sanitize ATP capsule summary, capabilities, and signals
- sanitize service listing metadata before publishing/updating services
- clamp service metadata fields and execution modes

Files:
- `src/atp/atpExecute.js`
- `src/atp/serviceHelper.js`
- `test/atpExecute.test.js`
- `test/serviceHelper.test.js`

### ATP delivery hardening
- sanitize auto-deliver proof payload signals
- clamp signal count and length in auto-deliver payloads
- write ATP delivery ledgers with tighter permissions
- use safer temp-file + rename writes for ATP delivery ledgers

Files:
- `src/atp/autoDeliver.js`
- `src/atp/heartbeatSignalsHandler.js`
- `test/atpAutoDeliver.test.js`
- `test/atpHeartbeatSignalsHandler.test.js`

## Behavior changes

This PR intentionally changes a few defaults:

- Hub-pushed feature flags are ignored unless `EVOLVER_ENABLE_HUB_FEATURE_FLAGS=true`
- auto issue reports omit log excerpts unless `EVOLVER_ISSUE_INCLUDE_LOGS=true`
- mailbox payloads and batches are bounded by default
- ATP publish and service metadata are sanitized before egress

These changes reduce accidental data exposure and make remote-influenced behavior more explicitly opt-in.

## Validation

Validated with targeted local checks:
- feature flag Hub-source opt-in behavior
- mailbox oversized payload and batch rejection
- sanitize coverage for node secrets, auth tokens, DB URLs, private IPs
- issue body redaction for raw node id, hostname, local paths, and logs
- ATP Capsule/service payload sanitization
- ATP auto-deliver proof payload sanitization
- module load checks for modified modules

Updated/added focused tests:
- `test/featureFlags.test.js`
- `test/mailboxStore.test.js`
- `test/sanitize.test.js`
- `test/issueReporter.test.js`
- `test/atpExecute.test.js`
- `test/serviceHelper.test.js`
- `test/atpAutoDeliver.test.js`
- `test/atpHeartbeatSignalsHandler.test.js`

## Test limitation

I could not reliably run the full `node --test` suite in this environment due to `spawn EPERM`.

## Follow-ups

Not included in this PR:
- OS/container-level validator isolation
- message-level signature/provenance verification for Hub events
- stronger signed-release / signed-skill trust chain
- broader CI validation workflow

## Note

Thanks again for explaining the distribution-mirror workflow.

If you are open to deeper follow-up work, I would be interested in helping audit or harden the equivalent internal-source paths as well, especially around validator isolation, Hub event provenance, and remote update trust chains.

I understand the public repo contains transformed/generated distribution files, so I’m not assuming direct access is available. If there is a preferred way to collaborate on deeper security work, private review, maintainer-guided issues, or scoped source access, I’d be happy to follow that process.


