### PR TITLE
fix(adapters): read tool_input.* in signal-detect for Claude Code

### DIFF
--- a/src/adapters/scripts/evolver-signal-detect.js
+++ b/src/adapters/scripts/evolver-signal-detect.js
@@ -38,8 +38,14 @@ function main() {
     handled = true;
     try {
       const input = inputData.trim() ? JSON.parse(inputData) : {};
-      const content = input.content || input.file_content || input.diff || '';
-      const filePath = input.path || input.file_path || '';
+      // Claude Code's PostToolUse payload nests tool args under tool_input.
+      // Older/raw shapes put them at the top level; support both.
+      const ti = input.tool_input || {};
+      const tr = input.tool_response || {};
+      const content = ti.content || ti.new_string || ti.file_content
+        || input.content || input.file_content || input.diff || '';
+      const filePath = ti.file_path || tr.filePath
+        || input.path || input.file_path || '';
 
       const signals = detectSignals(content);
 


### PR DESCRIPTION
## Summary

The Claude Code adapter's signal-detect hook (\`src/adapters/scripts/evolver-signal-detect.js\`) silently returns \`{}\` on every real \`PostToolUse\` event because it reads \`content\`/\`file_path\` from the top level of the JSON payload, but Claude Code nests tool args under \`tool_input\` (\`tool_input.content\`, \`tool_input.file_path\`).

Net effect on a default install: **the \`[Evolution Signal] Detected: [...]\` context block never fires**. Session-start and session-end hooks are unaffected; only signal-detect is silently dead.

## The fix

Check \`tool_input.*\` and \`tool_response.filePath\` first, fall back to the legacy top-level shape for backward compatibility. Also pick up \`new_string\` so Edit-tool payloads are analysed (previously only Write was reachable).

\`\`\`diff
- const content = input.content || input.file_content || input.diff || '';
- const filePath = input.path || input.file_path || '';
+ const ti = input.tool_input || {};
+ const tr = input.tool_response || {};
+ const content = ti.content || ti.new_string || ti.file_content
+   || input.content || input.file_content || input.diff || '';
+ const filePath = ti.file_path || tr.filePath
+   || input.path || input.file_path || '';
\`\`\`

## Verification

Pipe-tested against four payload shapes:

| # | Shape | Before | After |
|---|---|---|---|
| 1 | Claude Code \`Write\` (\`tool_input.content\`) | \`{}\` | signals detected |
| 2 | Claude Code \`Edit\` (\`tool_input.new_string\`) | \`{}\` | signals detected |
| 3 | Legacy top-level (\`content\`) | signals detected | signals detected (preserved) |
| 4 | Empty / no signal keywords | \`{}\` | \`{}\` |

Reference for the Claude Code payload shape: https://docs.claude.com/en/docs/claude-code/hooks-guide#hook-input

## Scope

- Single file changed: \`src/adapters/scripts/evolver-signal-detect.js\` (+8/-2)
- No behavior change for non-Claude-Code adapters or legacy callers
- No docs needed; this restores intended documented behavior