### PR TITLE
fix: harden setup-hooks clean install path

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,74 @@ try {
   else process.env.EVOLVER_QUIET_PARENT_GIT = _prevQuiet;
 } catch (e) { /* dotenv is optional */ }
 
+async function runSetupHooksCli(args) {
+  const hookAdapter = require('./src/adapters/hookAdapter');
+  const { setupHooks, resolveConfigRoot, detectPlatform, loadAdapter } = hookAdapter;
+
+  const platformFlag = args.find(a => typeof a === 'string' && a.startsWith('--platform='));
+  const platform = platformFlag ? platformFlag.slice('--platform='.length) : undefined;
+  const force = args.includes('--force');
+  const uninstall = args.includes('--uninstall');
+  const verifyOnly = args.includes('--verify');
+
+  if (verifyOnly) {
+    try {
+      const platformId = platform || detectPlatform(process.cwd());
+      if (!platformId) {
+        console.error('[setup-hooks] --verify: could not detect platform. Pass --platform=opencode|cursor|claude-code|codex|kiro');
+        process.exit(2);
+      }
+      const adapter = loadAdapter(platformId);
+      if (!adapter || typeof adapter.verify !== 'function') {
+        console.error('[setup-hooks] --verify: platform ' + platformId + ' does not support verification yet.');
+        process.exit(2);
+      }
+      const configRoot = resolveConfigRoot(platformId, process.cwd());
+      const report = adapter.verify({ configRoot });
+      if (typeof adapter.printVerifyReport === 'function') {
+        adapter.printVerifyReport(report);
+      } else {
+        console.log(JSON.stringify(report, null, 2));
+      }
+      process.exit(report.ok ? 0 : 1);
+    } catch (verifyErr) {
+      console.error('[setup-hooks] --verify error:', verifyErr && verifyErr.message || verifyErr);
+      process.exit(1);
+    }
+  }
+
+  try {
+    const result = await setupHooks({
+      platform,
+      cwd: process.cwd(),
+      force,
+      uninstall,
+      evolverRoot: __dirname,
+    });
+    if (result && result.ok) {
+      if (!uninstall && result.files) {
+        console.log('\n[setup-hooks] Files created/updated:');
+        for (const f of result.files) {
+          console.log('  ' + f);
+        }
+      }
+      process.exit(0);
+    } else {
+      console.error('[setup-hooks] Failed: ' + (result && result.error || 'unknown'));
+      process.exit(1);
+    }
+  } catch (error) {
+    console.error('[setup-hooks] Error:', error && error.message || error);
+    process.exit(1);
+  }
+}
+
+if (require.main === module && process.argv[2] === 'setup-hooks') {
+  runSetupHooksCli(process.argv.slice(3)).catch(function (err) {
+    console.error('[setup-hooks] Error:', err && err.stack ? err.stack : String(err));
+    process.exitCode = 1;
+  });
+} else {
 const evolve = require('./src/evolve');
 const { solidify } = require('./src/gep/solidify');
 const path = require('path');
@@ -1660,70 +1728,6 @@ async function main() {
       process.exit(1);
     }
 
-  } else if (command === 'setup-hooks') {
-    const hookAdapter = require('./src/adapters/hookAdapter');
-    const { setupHooks, resolveConfigRoot, detectPlatform, loadAdapter } = hookAdapter;
-
-    const platformFlag = args.find(a => typeof a === 'string' && a.startsWith('--platform='));
-    const platform = platformFlag ? platformFlag.slice('--platform='.length) : undefined;
-    const force = args.includes('--force');
-    const uninstall = args.includes('--uninstall');
-    const verifyOnly = args.includes('--verify');
-
-    if (verifyOnly) {
-      // Read-only verification: do not touch any files, just report whether
-      // the previously-installed hooks/plugin look healthy. Lets users answer
-      // "is the plugin actually loaded?" without grepping opencode logs.
-      try {
-        const platformId = platform || detectPlatform(process.cwd());
-        if (!platformId) {
-          console.error('[setup-hooks] --verify: could not detect platform. Pass --platform=opencode|cursor|claude-code|codex|kiro');
-          process.exit(2);
-        }
-        const adapter = loadAdapter(platformId);
-        if (!adapter || typeof adapter.verify !== 'function') {
-          console.error('[setup-hooks] --verify: platform ' + platformId + ' does not support verification yet.');
-          process.exit(2);
-        }
-        const configRoot = resolveConfigRoot(platformId, process.cwd());
-        const report = adapter.verify({ configRoot });
-        if (typeof adapter.printVerifyReport === 'function') {
-          adapter.printVerifyReport(report);
-        } else {
-          console.log(JSON.stringify(report, null, 2));
-        }
-        process.exit(report.ok ? 0 : 1);
-      } catch (verifyErr) {
-        console.error('[setup-hooks] --verify error:', verifyErr && verifyErr.message || verifyErr);
-        process.exit(1);
-      }
-    }
-
-    try {
-      const result = await setupHooks({
-        platform,
-        cwd: process.cwd(),
-        force,
-        uninstall,
-        evolverRoot: __dirname,
-      });
-      if (result && result.ok) {
-        if (!uninstall && result.files) {
-          console.log('\n[setup-hooks] Files created/updated:');
-          for (const f of result.files) {
-            console.log('  ' + f);
-          }
-        }
-        process.exit(0);
-      } else {
-        console.error('[setup-hooks] Failed: ' + (result && result.error || 'unknown'));
-        process.exit(1);
-      }
-    } catch (error) {
-      console.error('[setup-hooks] Error:', error && error.message || error);
-      process.exit(1);
-    }
-
   } else if (command === 'reset-local-secret') {
     // Wipe every local store of node_secret in one shot, so a daemon stuck
     // after a manual web reset (https://evomap.ai/account -> Reset Secret)
@@ -1923,6 +1927,7 @@ if (require.main === module) {
 
 module.exports = {
   main,
+  runSetupHooksCli,
   readJsonSafe,
   rejectPendingRun,
   isPendingSolidify,
@@ -1931,3 +1936,4 @@ module.exports = {
   writeCycleProgressAtomic,
   spawnReplacementProcess,
 };
+}

--- a/src/adapters/hookAdapter.js
+++ b/src/adapters/hookAdapter.js
@@ -153,12 +153,11 @@ function assertNotSymlink(p, label) {
 
 function copyHookScripts(destDir, evolverRoot) {
   const scriptsDir = path.join(evolverRoot || __dirname, 'scripts');
-  // _runtimePaths.js is required by the two session-* scripts via
-  // `require('./_runtimePaths')`, which resolves relative to the *destination*
-  // (__dirname after copy). It MUST be copied alongside or both hooks crash
-  // with MODULE_NOT_FOUND at runtime. Caught in PR #94 review.
+  // Helper modules are required by copied hook scripts via relative require()
+  // calls, which resolve against the destination hook directory at runtime.
   const scripts = [
     '_runtimePaths.js',
+    '_memoryFiltering.js',
     'evolver-session-start.js',
     'evolver-signal-detect.js',
     'evolver-session-end.js',
@@ -237,6 +236,7 @@ function removeEvolverHooks(filePath, { markerKey = '_evolver_managed' } = {}) {
 function removeHookScripts(hooksDir) {
   const scripts = [
     '_runtimePaths.js',
+    '_memoryFiltering.js',
     'evolver-session-start.js',
     'evolver-signal-detect.js',
     'evolver-session-end.js',

--- a/src/adapters/scripts/evolver-session-start.js
+++ b/src/adapters/scripts/evolver-session-start.js
@@ -10,6 +10,55 @@ const os = require('os');
 const { findEvolverRoot, findMemoryGraph } = require('./_runtimePaths');
 const { filterRelevantOutcomes } = require('./_memoryFiltering');
 
+function findGitRoot(start) {
+  let dir = path.resolve(start || process.cwd());
+  while (dir !== path.dirname(dir)) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    dir = path.dirname(dir);
+  }
+  return null;
+}
+
+function resolveWorkspaceRootForReader() {
+  if (process.env.OPENCLAW_WORKSPACE) return process.env.OPENCLAW_WORKSPACE;
+  const repoRoot = process.env.EVOLVER_REPO_ROOT || findGitRoot(process.cwd()) || process.cwd();
+  const workspaceDir = path.join(repoRoot, 'workspace');
+  if (fs.existsSync(workspaceDir)) return workspaceDir;
+  return repoRoot;
+}
+
+function resolveWorkspaceIdForReader() {
+  if (process.env.EVOLVER_WORKSPACE_ID) return String(process.env.EVOLVER_WORKSPACE_ID);
+  const file = path.join(resolveWorkspaceRootForReader(), '.evolver', 'workspace-id');
+  try {
+    const dirStat = fs.lstatSync(path.dirname(file), { throwIfNoEntry: false });
+    if (dirStat && dirStat.isSymbolicLink()) return null;
+    const fileStat = fs.lstatSync(file, { throwIfNoEntry: false });
+    if (!fileStat || fileStat.isSymbolicLink() || !fileStat.isFile()) return null;
+    const raw = fs.readFileSync(file, 'utf8').trim();
+    if (raw && /^[a-f0-9]{32,}$/i.test(raw)) return raw;
+  } catch { /* workspace id is best-effort in copied hooks */ }
+  return null;
+}
+
+function filterWorkspaceEntries(entries) {
+  const cwd = process.cwd();
+  const workspaceId = resolveWorkspaceIdForReader();
+
+  return entries.filter(entry => {
+    if (!entry || typeof entry !== 'object') return false;
+    if (workspaceId && entry.workspace_id) {
+      return String(entry.workspace_id) === String(workspaceId);
+    }
+    if (entry.cwd) {
+      return path.resolve(String(entry.cwd)) === path.resolve(cwd);
+    }
+    // Older entries did not carry a workspace tag. Do not inject them from
+    // hooks because copied hooks often share a user-level fallback memory file.
+    return false;
+  });
+}
+
 function readLastN(filePath, n) {
   try {
     const content = fs.readFileSync(filePath, 'utf8');
@@ -100,8 +149,9 @@ function main() {
     return;
   }
 
-  const entries = readLastN(graphPath, 5);
-  const filtered = filterRelevantOutcomes(entries);
+  const entries = readLastN(graphPath, 20);
+  const scoped = filterWorkspaceEntries(entries);
+  const filtered = filterRelevantOutcomes(scoped);
 
   if (filtered.length === 0) {
     process.stdout.write(JSON.stringify({}));

--- a/src/adapters/scripts/evolver-signal-detect.js
+++ b/src/adapters/scripts/evolver-signal-detect.js
@@ -51,6 +51,30 @@ function detectSignals(text) {
   return [...new Set(found)];
 }
 
+function getToolName(input) {
+  const raw = input.tool_name || input.toolName || input.name || input.tool;
+  if (typeof raw === 'string') return raw;
+  if (raw && typeof raw.name === 'string') return raw.name;
+  return '';
+}
+
+function isWriteLikeTool(input) {
+  const name = getToolName(input).toLowerCase();
+  // Older hook payloads did not include a tool name. Keep those compatible
+  // and let the content/path checks below decide whether there is work to do.
+  if (!name) return true;
+  return (
+    name === 'write' ||
+    name === 'edit' ||
+    name === 'multiedit' ||
+    name === 'notebookedit' ||
+    name === 'apply_patch' ||
+    name.includes('write') ||
+    name.includes('edit') ||
+    name.includes('patch')
+  );
+}
+
 function main() {
   let inputData = '';
   let handled = false;
@@ -61,6 +85,10 @@ function main() {
     handled = true;
     try {
       const input = inputData.trim() ? JSON.parse(inputData) : {};
+      if (!isWriteLikeTool(input)) {
+        process.stdout.write(JSON.stringify({}));
+        return;
+      }
       // Claude Code's PostToolUse payload nests tool args under tool_input.
       // Older/raw shapes put them at the top level; support both.
       const ti = input.tool_input || {};

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
+const { spawnSync } = require('child_process');
 
 const hookAdapter = require('../src/adapters/hookAdapter');
 const cursorAdapter = require('../src/adapters/cursor');
@@ -15,6 +16,25 @@ function makeTmpDir() {
 
 function cleanup(dir) {
   try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+function runNode(args, opts = {}) {
+  return spawnSync(process.execPath, args, {
+    cwd: opts.cwd,
+    env: { ...process.env, ...(opts.env || {}) },
+    input: opts.input,
+    encoding: 'utf8',
+    timeout: opts.timeout || 10000,
+  });
+}
+
+function runGit(args, cwd, env) {
+  return spawnSync('git', args, {
+    cwd,
+    env: { ...process.env, ...(env || {}) },
+    encoding: 'utf8',
+    timeout: 10000,
+  });
 }
 
 // -- hookAdapter --
@@ -133,15 +153,15 @@ describe('hookAdapter', () => {
         const destDir = path.join(tmp, 'hooks');
         const evolverRoot = path.resolve(__dirname, '..');
         const copied = hookAdapter.copyHookScripts(destDir, path.join(evolverRoot, 'src', 'adapters'));
-        // 3 hook entry points + _runtimePaths helper required by two of them.
-        assert.equal(copied.length, 4);
+        // 3 hook entry points + helper modules required by copied scripts.
+        assert.equal(copied.length, 5);
         for (const f of copied) {
           assert.ok(fs.existsSync(f));
         }
       } finally { cleanup(tmp); }
     });
 
-    it('includes _runtimePaths.js so copied session hooks can require it (PR #94)', () => {
+    it('includes helper modules so copied session hooks can require them', () => {
       const tmp = makeTmpDir();
       try {
         const destDir = path.join(tmp, 'hooks');
@@ -149,9 +169,11 @@ describe('hookAdapter', () => {
         hookAdapter.copyHookScripts(destDir, path.join(evolverRoot, 'src', 'adapters'));
         assert.ok(fs.existsSync(path.join(destDir, '_runtimePaths.js')),
           '_runtimePaths.js must ship alongside session-start/end or both crash with MODULE_NOT_FOUND');
+        assert.ok(fs.existsSync(path.join(destDir, '_memoryFiltering.js')),
+          '_memoryFiltering.js must ship alongside session-start or it crashes with MODULE_NOT_FOUND');
 
-        // End-to-end: actually run the copied script. If `_runtimePaths.js`
-        // is missing the require() at top of file would fail with
+        // End-to-end: actually run the copied script. If a helper module is
+        // missing the require() at top of file would fail with
         // MODULE_NOT_FOUND and exit non-zero.
         const { spawnSync } = require('child_process');
         const result = spawnSync('node', [path.join(destDir, 'evolver-session-start.js')], {
@@ -170,12 +192,13 @@ describe('hookAdapter', () => {
         const hooksDir = path.join(tmp, 'hooks');
         fs.mkdirSync(hooksDir, { recursive: true });
         fs.writeFileSync(path.join(hooksDir, '_runtimePaths.js'), '');
+        fs.writeFileSync(path.join(hooksDir, '_memoryFiltering.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'evolver-session-start.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'evolver-signal-detect.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'evolver-session-end.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'user-custom.js'), '');
         const removed = hookAdapter.removeHookScripts(hooksDir);
-        assert.equal(removed, 4);
+        assert.equal(removed, 5);
         assert.ok(fs.existsSync(path.join(hooksDir, 'user-custom.js')));
       } finally { cleanup(tmp); }
     });
@@ -891,5 +914,142 @@ describe('codex adapter', () => {
       assert.ok(postCmds.includes('node my-watcher.js'));
       assert.ok(postCmds.some(c => c.includes('evolver-signal-detect')));
     } finally { cleanup(tmp); }
+  });
+});
+
+describe('setup-hooks clean sandbox integration', () => {
+  function initWorkspace(root, name) {
+    const ws = path.join(root, name);
+    fs.mkdirSync(ws, { recursive: true });
+    runGit(['init'], ws);
+    runGit(['config', 'user.email', 'sandbox@example.invalid'], ws);
+    runGit(['config', 'user.name', 'Sandbox'], ws);
+    fs.writeFileSync(path.join(ws, 'README.md'), '# sandbox\n', 'utf8');
+    runGit(['add', 'README.md'], ws);
+    runGit(['commit', '-m', 'init'], ws);
+    return ws;
+  }
+
+  function exercisePlatform(platform) {
+    const root = makeTmpDir();
+    const home = path.join(root, 'home');
+    const ws = initWorkspace(root, `${platform}-workspace`);
+    const repoRoot = path.resolve(__dirname, '..');
+    fs.mkdirSync(home, { recursive: true });
+    const env = {
+      HOME: home,
+      EVOLVER_HOOK_LOG_DIR: path.join(home, '.evolver', 'logs'),
+      EVOLVER_SESSION_STATE_DIR: path.join(home, '.evolver'),
+    };
+
+    try {
+      const install = runNode([path.join(repoRoot, 'index.js'), 'setup-hooks', `--platform=${platform}`], {
+        cwd: ws,
+        env,
+      });
+      assert.equal(install.status, 0, install.stderr);
+      assert.match(install.stdout, /Files created\/updated/);
+
+      const isCodex = platform === 'codex';
+      const configDir = path.join(ws, isCodex ? '.codex' : '.claude');
+      const hookDir = path.join(configDir, 'hooks');
+      const hookFiles = fs.readdirSync(hookDir).sort();
+      assert.deepEqual(hookFiles, [
+        '_memoryFiltering.js',
+        '_runtimePaths.js',
+        'evolver-session-end.js',
+        'evolver-session-start.js',
+        'evolver-signal-detect.js',
+      ]);
+
+      if (isCodex) {
+        const toml = fs.readFileSync(path.join(configDir, 'config.toml'), 'utf8');
+        assert.match(toml, /codex_hooks\s*=\s*true/);
+      }
+
+      const signalScript = path.join(hookDir, 'evolver-signal-detect.js');
+      const readOnly = runNode([signalScript], {
+        cwd: ws,
+        env,
+        input: JSON.stringify({ tool_name: 'Read', tool_input: { content: 'please add feature' } }) + '\n',
+      });
+      assert.equal(readOnly.status, 0, readOnly.stderr);
+      assert.equal(readOnly.stdout.trim(), '{}');
+
+      const signal = runNode([signalScript], {
+        cwd: ws,
+        env,
+        input: JSON.stringify({
+          tool_name: 'Write',
+          tool_input: {
+            file_path: 'src/example.js',
+            content: 'please add feature for timeout handling\n',
+          },
+        }) + '\n',
+      });
+      assert.equal(signal.status, 0, signal.stderr);
+      assert.match(signal.stdout, /perf_bottleneck/);
+      assert.match(signal.stdout, /user_feature_request/);
+
+      const otherWs = initWorkspace(root, `${platform}-other-workspace`);
+      const otherMemoryDir = path.join(home, '.evolver', 'memory', 'evolution');
+      fs.mkdirSync(otherMemoryDir, { recursive: true });
+      fs.appendFileSync(path.join(otherMemoryDir, 'memory_graph.jsonl'), JSON.stringify({
+        timestamp: new Date().toISOString(),
+        gene_id: 'ad_hoc',
+        signals: ['capability_gap'],
+        outcome: { status: 'success', score: 0.9, note: 'other workspace should not leak' },
+        cwd: otherWs,
+        workspace_id: null,
+        source: 'hook:session-end',
+      }) + '\n', 'utf8');
+
+      const workspaceDir = path.join(ws, 'workspace');
+      const workspaceId = '0123456789abcdef0123456789abcdef';
+      fs.mkdirSync(path.join(workspaceDir, '.evolver'), { recursive: true });
+      fs.writeFileSync(path.join(workspaceDir, '.evolver', 'workspace-id'), workspaceId + '\n', 'utf8');
+      fs.appendFileSync(path.join(otherMemoryDir, 'memory_graph.jsonl'), JSON.stringify({
+        timestamp: new Date().toISOString(),
+        gene_id: 'ad_hoc',
+        signals: ['deployment_issue'],
+        outcome: { status: 'success', score: 0.9, note: 'workspace id matched entry' },
+        cwd: path.join(ws, 'not-the-current-cwd'),
+        workspace_id: workspaceId,
+        source: 'hook:session-end',
+      }) + '\n', 'utf8');
+
+      fs.appendFileSync(path.join(ws, 'README.md'), 'please add feature for timeout handling\n', 'utf8');
+      const stop = runNode([path.join(hookDir, 'evolver-session-end.js')], {
+        cwd: ws,
+        env,
+        input: '{}\n',
+        timeout: 12000,
+      });
+      assert.equal(stop.status, 0, stop.stderr);
+
+      const start = runNode([path.join(hookDir, 'evolver-session-start.js')], {
+        cwd: ws,
+        env,
+        input: '{}\n',
+      });
+      assert.equal(start.status, 0, start.stderr);
+      assert.equal(fs.existsSync(path.join(ws, '.evolver', 'workspace-id')), false,
+        'SessionStart must not create workspace-id as a read-side side effect');
+      assert.match(start.stdout, /Evolution Memory/);
+      assert.match(start.stdout, /workspace id matched entry/);
+      assert.match(start.stdout, /perf_bottleneck/);
+      assert.match(start.stdout, /user_feature_request/);
+      assert.doesNotMatch(start.stdout, /other workspace should not leak/);
+    } finally {
+      cleanup(root);
+    }
+  }
+
+  it('installs and runs Claude Code hooks in a clean HOME/workspace', () => {
+    exercisePlatform('claude-code');
+  });
+
+  it('installs and runs Codex hooks in a clean HOME/workspace', () => {
+    exercisePlatform('codex');
   });
 });


### PR DESCRIPTION
## Summary
- route `setup-hooks` through an early CLI path so hook installation does not require unrelated evolve/Hub dependencies
- ship all copied hook helper modules, including `_memoryFiltering.js`
- filter Codex/global PostToolUse payloads to write-like tools before signal scanning
- scope SessionStart memory injection to the current workspace without creating `.evolver/workspace-id` as a read-side effect
- add clean HOME/workspace integration coverage for Claude Code and Codex hooks

## Review / dry run
- Reviewed the diff for new side effects; found and fixed a read-side `SessionStart` workspace-id creation issue
- Idempotency dry-run passed for Claude Code and Codex: repeated install keeps one Evolver hook per event, preserves user hooks, uninstall removes Evolver hooks only, second uninstall succeeds, no workspace `.evolver` side effect
- Verified `setup-hooks --platform=codex` still works after temporarily removing `node_modules/undici`
- `npm pack --dry-run` passed and includes the fixed adapter scripts

## Tests
- `node --check index.js`
- `node --check src/adapters/scripts/evolver-session-start.js`
- `node --check src/adapters/scripts/evolver-signal-detect.js`
- `node --test test/adapters.test.js`
- `node --test test/adapters.test.js test/adaptersSyntax.test.js test/adapters.kiro.test.js test/adapters.opencode.test.js`

## Release note
README documents `npm run publish:public`, but the current `package.json` has no `publish:public` script, so this PR stops at pack dry-run and PR creation rather than publishing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent-facing hook behavior (memory injection scoping and PostToolUse signal filtering) and the CLI bootstrap path for setup-hooks; impact is localized to hook install/runtime but affects what context agents see in sessions.
> 
> **Overview**
> **`setup-hooks` now runs through an early entry path in `index.js`** (right after dotenv bootstrap) so install/verify/uninstall only loads `hookAdapter`, avoiding unrelated evolve/Hub dependencies that could break clean installs.
> 
> Hook packaging and runtime behavior are tightened: **`_memoryFiltering.js` is copied and removed with the other hook scripts**, **`evolver-signal-detect.js` ignores non write-like PostToolUse tools** (e.g. `Read`), and **`evolver-session-start.js` scopes injected memory to the current workspace** via `workspace_id` / `cwd`, reads a larger recent window, and **does not create `.evolver/workspace-id` on SessionStart**.
> 
> **New clean HOME/workspace integration tests** exercise Claude Code and Codex install plus end-to-end hook runs (signal gating, workspace isolation, no read-side workspace-id side effect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 565260a846740d5b2661dd5e8b201d9839a2a98e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->