### PR TITLE
docs: align public release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,28 +497,25 @@ The `sessions_spawn(...)` strings in `index.js` and `evolve.js` are **text outpu
 
 This repository is the public distribution.
 
-- Build public output: `npm run build`
-- Publish public output: `npm run publish:public`
-- Dry run: `DRY_RUN=true npm run publish:public`
+Before publishing, verify the release from a clean `main` checkout:
 
-Required env vars:
+```bash
+npm view @evomap/evolver version
+node --test test/adapters.test.js test/adaptersSyntax.test.js test/adapters.kiro.test.js test/adapters.opencode.test.js
+npm pack --dry-run
+npm publish --dry-run --access public
+```
 
-- `PUBLIC_REMOTE` (default: `public`)
-- `PUBLIC_REPO` (e.g. `EvoMap/evolver`)
-- `PUBLIC_OUT_DIR` (default: `dist-public`)
-- `PUBLIC_USE_BUILD_OUTPUT` (default: `true`)
+Patch releases use the standard npm version flow:
 
-Optional env vars:
+```bash
+npm version patch -m "Release v%s"
+git push origin main --tags
+npm publish --access public
+npm view @evomap/evolver version
+```
 
-- `SOURCE_BRANCH` (default: `main`)
-- `PUBLIC_BRANCH` (default: `main`)
-- `RELEASE_TAG` (e.g. `v1.0.41`)
-- `RELEASE_TITLE` (e.g. `v1.0.41 - GEP protocol`)
-- `RELEASE_NOTES` or `RELEASE_NOTES_FILE`
-- `GITHUB_TOKEN` (or `GH_TOKEN` / `GITHUB_PAT`) for GitHub Release creation
-- `RELEASE_SKIP` (`true` to skip creating a GitHub Release; default is to create)
-- `RELEASE_USE_GH` (`true` to use `gh` CLI instead of GitHub API)
-- `PUBLIC_RELEASE_ONLY` (`true` to only create a Release for an existing tag; no publish)
+After publishing, create a GitHub Release from the pushed tag.
 
 ## Versioning (SemVer)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "license": "GPL-3.0-or-later",
   "repository": {
     "type": "git",
-    "url": "https://github.com/EvoMap/evolver.git"
+    "url": "git+https://github.com/EvoMap/evolver.git"
   },
   "homepage": "https://evomap.ai",
   "scripts": {

--- a/scripts/check-changelog.js
+++ b/scripts/check-changelog.js
@@ -34,7 +34,9 @@ const path = require('path');
 const DEFAULT_REPO_ROOT = path.resolve(__dirname, '..');
 
 function readChangelogAtHead(repoRoot) {
-  return fs.readFileSync(path.join(repoRoot, 'CHANGELOG.md'), 'utf8');
+  const changelogPath = path.join(repoRoot, 'CHANGELOG.md');
+  if (!fs.existsSync(changelogPath)) return null;
+  return fs.readFileSync(changelogPath, 'utf8');
 }
 
 function readChangelogAtRef(repoRoot, ref) {
@@ -98,6 +100,13 @@ function extractSection(text, version) {
 function checkChangelogIntegrity(opts) {
   const repoRoot = (opts && opts.repoRoot) || DEFAULT_REPO_ROOT;
   const head = readChangelogAtHead(repoRoot);
+  if (head == null) {
+    return {
+      drift: [],
+      skipped: [{ version: '*', reason: 'CHANGELOG.md not present in this repository' }],
+      checked: 0,
+    };
+  }
   const versions = listReleasedVersionHeadings(head);
 
   const drift = [];

--- a/test/checkChangelog.test.js
+++ b/test/checkChangelog.test.js
@@ -141,4 +141,21 @@ describe('check-changelog integration (#113)', () => {
       fs.rmSync(repoDir, { recursive: true, force: true });
     }
   });
+
+  it('skips cleanly when the repository has no CHANGELOG.md', () => {
+    const repoDir = setupRepo();
+    try {
+      fs.writeFileSync(path.join(repoDir, 'README.md'), '# no changelog here\n', 'utf8');
+      runGit(repoDir, ['add', 'README.md']);
+      runGit(repoDir, ['commit', '-q', '-m', 'initial']);
+
+      const r = checkChangelogIntegrity({ repoRoot: repoDir });
+      assert.deepEqual(r.drift, []);
+      assert.equal(r.checked, 0);
+      assert.equal(r.skipped.length, 1);
+      assert.equal(r.skipped[0].reason, 'CHANGELOG.md not present in this repository');
+    } finally {
+      fs.rmSync(repoDir, { recursive: true, force: true });
+    }
+  });
 });


### PR DESCRIPTION
## Summary
- Document the actual npm release commands instead of the removed publish:public script
- Normalize package repository.url so npm publish no longer auto-corrects it
- Make the changelog guard skip cleanly when this repo has no CHANGELOG.md

## Tests
- node --test test/checkChangelog.test.js
- node scripts/check-changelog.js
- npm pkg fix --dry-run
- timeout 20 npm publish --dry-run --access public (expected registry duplicate-version failure for already-published 1.86.1; no package metadata warning)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and release-tooling tweaks only; no runtime evolution or security behavior changes.
> 
> **Overview**
> **Public release docs** now describe the real npm flow (pre-publish checks, `npm version patch`, push tags, `npm publish`) instead of the removed `publish:public` script and its env-var matrix.
> 
> **Package metadata**: `repository.url` is normalized to the `git+https://...` form npm expects, avoiding publish-time auto-correction warnings.
> 
> **Changelog guard**: `checkChangelogIntegrity` no longer assumes `CHANGELOG.md` exists; repos without one get a single skip reason and exit cleanly. A test covers that path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57bb99d8a27c88d657a09536fc6febe9a98ae367. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->