### PR TITLE
fix: copy _memoryFiltering.js in setup-hooks (#547)

### DIFF
--- a/src/adapters/hookAdapter.js
+++ b/src/adapters/hookAdapter.js
@@ -159,6 +159,7 @@ function copyHookScripts(destDir, evolverRoot) {
   // with MODULE_NOT_FOUND at runtime. Caught in PR #94 review.
   const scripts = [
     '_runtimePaths.js',
+    '_memoryFiltering.js',
     'evolver-session-start.js',
     'evolver-signal-detect.js',
     'evolver-session-end.js',
@@ -237,6 +238,7 @@ function removeEvolverHooks(filePath, { markerKey = '_evolver_managed' } = {}) {
 function removeHookScripts(hooksDir) {
   const scripts = [
     '_runtimePaths.js',
+    '_memoryFiltering.js',
     'evolver-session-start.js',
     'evolver-signal-detect.js',
     'evolver-session-end.js',

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -140,8 +140,9 @@ describe('hookAdapter', () => {
         const destDir = path.join(tmp, 'hooks');
         const evolverRoot = path.resolve(__dirname, '..');
         const copied = hookAdapter.copyHookScripts(destDir, path.join(evolverRoot, 'src', 'adapters'));
-        // 3 hook entry points + _runtimePaths helper required by two of them.
-        assert.equal(copied.length, 4);
+        // 3 hook entry points + _runtimePaths and _memoryFiltering helpers
+        // required by session-start.
+        assert.equal(copied.length, 5);
         for (const f of copied) {
           assert.ok(fs.existsSync(f));
         }
@@ -168,6 +169,17 @@ describe('hookAdapter', () => {
           `copied evolver-session-start.js must run without error. stderr=${result.stderr}`);
       } finally { cleanup(tmp); }
     });
+
+    it('includes _memoryFiltering.js so copied session-start can require it (#547)', () => {
+      const tmp = makeTmpDir();
+      try {
+        const destDir = path.join(tmp, 'hooks');
+        const evolverRoot = path.resolve(__dirname, '..');
+        hookAdapter.copyHookScripts(destDir, path.join(evolverRoot, 'src', 'adapters'));
+        assert.ok(fs.existsSync(path.join(destDir, '_memoryFiltering.js')),
+          '_memoryFiltering.js must ship alongside session-start or it crashes with MODULE_NOT_FOUND');
+      } finally { cleanup(tmp); }
+    });
   });
 
   describe('removeHookScripts', () => {
@@ -177,12 +189,13 @@ describe('hookAdapter', () => {
         const hooksDir = path.join(tmp, 'hooks');
         fs.mkdirSync(hooksDir, { recursive: true });
         fs.writeFileSync(path.join(hooksDir, '_runtimePaths.js'), '');
+        fs.writeFileSync(path.join(hooksDir, '_memoryFiltering.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'evolver-session-start.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'evolver-signal-detect.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'evolver-session-end.js'), '');
         fs.writeFileSync(path.join(hooksDir, 'user-custom.js'), '');
         const removed = hookAdapter.removeHookScripts(hooksDir);
-        assert.equal(removed, 4);
+        assert.equal(removed, 5);
         assert.ok(fs.existsSync(path.join(hooksDir, 'user-custom.js')));
       } finally { cleanup(tmp); }
     });


### PR DESCRIPTION
## Summary

Generated `evolver-session-start.js` requires `./_memoryFiltering` at the top of the file, but `copyHookScripts` was never updated to copy the helper alongside it. A fresh `setup-hooks --platform=codex` produced a hook that crashed immediately with `MODULE_NOT_FOUND`. This adds `_memoryFiltering.js` to both the copy list and the cleanup list. Closes #547.

## What changed

- `src/adapters/hookAdapter.js`: add `_memoryFiltering.js` to `copyHookScripts` and `removeHookScripts` so the install/uninstall manifests cover every runtime dependency of the generated session hooks.
- `test/adapters.test.js`: bump the `copyHookScripts` count assertion from 4 to 5, add a `_memoryFiltering.js` presence assertion mirroring the existing `_runtimePaths.js` regression test, and update the `removeHookScripts` fixture to include the new file.

## How to test

```bash
# Run the modified suite
node --test test/adapters.test.js

# End-to-end: clean fresh install path
rm -rf /tmp/evolver-547 && mkdir /tmp/evolver-547
node -e "
const hookAdapter = require('./src/adapters/hookAdapter');
const path = require('path');
const copied = hookAdapter.copyHookScripts('/tmp/evolver-547/hooks', path.join(__dirname, 'src', 'adapters'));
console.log('copied:', copied.length); // 5
require('child_process').spawnSync('node', ['/tmp/evolver-547/hooks/evolver-session-start.js'], { input: '{}', stdio: 'inherit' });
"
# Expected: exit 0, no MODULE_NOT_FOUND
```

## Risk

Low. The change is two `string` entries added to two `const scripts = [...]` arrays. Both lists are explicit allowlists, so callers depending on the prior length (4 entries) would need to fail closed; the only such caller in-repo is the copyHookScripts test, which is updated in this PR.

## Self-check

- [x] No new runtime dependencies added.
- [x] Tests added or updated to cover the new behavior.
- [ ] Not adding a new source file under `src/`.
- [ ] Not adding or modifying a schema factory.
- [ ] Not using `Object.assign({}, DEFAULTS, ...)`.
- [ ] Not adding a new module-level constant from `process.env`.

## Related

Closes #547

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Two allowlist entries in install/uninstall helpers; behavior matches the existing `_runtimePaths.js` pattern with updated tests only.
> 
> **Overview**
> Fixes fresh `setup-hooks` installs where **`evolver-session-start.js`** fails immediately with **`MODULE_NOT_FOUND`** because it **`require('./_memoryFiltering')`** but that helper was never copied into the platform hooks directory.
> 
> **`copyHookScripts`** and **`removeHookScripts`** now include **`_memoryFiltering.js`** in the same allowlist as **`_runtimePaths.js`**, so install/uninstall ship and clean every runtime dependency of the generated session hooks.
> 
> Tests expect **5** copied/removed scripts and add a presence check for **`_memoryFiltering.js`**, parallel to the existing **`_runtimePaths.js`** regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 092334a5db85e6a9d64c299069038a9a94351335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->