### PR TITLE
fix(hooks): workspace-scope memory recall + log a no-changes breadcrumb

### DIFF
--- a/src/adapters/scripts/_runtimePaths.js
+++ b/src/adapters/scripts/_runtimePaths.js
@@ -111,6 +111,27 @@ function resolveProjectDir() {
   return process.cwd();
 }
 
+// Resolve the current workspace id — the forge-resistant tag the session-end
+// writer stamps on every memory-graph entry (`workspace_id`). The session-start
+// reader needs the SAME value to scope which past outcomes belong to this
+// workspace, so this helper mirrors the writer's resolution exactly
+// (evolver-session-end.js#resolveWorkspaceIdForWriter):
+//   1. EVOLVER_WORKSPACE_ID env override
+//   2. paths.getWorkspaceId() loaded from the resolved evolver root
+// Returns null when neither is available (e.g. evolver package not installed),
+// in which case callers must NOT filter — falling back to "show everything"
+// preserves prior behavior rather than hiding all memory on a resolution miss.
+function resolveWorkspaceId(evolverRoot) {
+  if (process.env.EVOLVER_WORKSPACE_ID) return String(process.env.EVOLVER_WORKSPACE_ID);
+  const root = evolverRoot || findEvolverRoot();
+  if (!root) return null;
+  try {
+    const paths = require(path.join(root, 'src', 'gep', 'paths.js'));
+    if (typeof paths.getWorkspaceId === 'function') return paths.getWorkspaceId();
+  } catch { /* paths.js unreachable — return null */ }
+  return null;
+}
+
 // Returns a path to the evolution memory graph, or a fallback location that
 // is guaranteed to be writable. Never returns null — when no evolver root is
 // available, we fall back to `~/.evolver/memory/evolution/memory_graph.jsonl`
@@ -142,4 +163,4 @@ function findMemoryGraph(evolverRoot) {
   return path.join(userDir, 'memory_graph.jsonl');
 }
 
-module.exports = { findEvolverRoot, findMemoryGraph, resolveProjectDir };
+module.exports = { findEvolverRoot, findMemoryGraph, resolveProjectDir, resolveWorkspaceId };

--- a/src/adapters/scripts/_runtimePaths.js
+++ b/src/adapters/scripts/_runtimePaths.js
@@ -112,10 +112,13 @@ function resolveProjectDir() {
 }
 
 // Resolve the current workspace id — the forge-resistant tag the session-end
-// writer stamps on every memory-graph entry (`workspace_id`). The session-start
-// reader needs the SAME value to scope which past outcomes belong to this
-// workspace, so this helper mirrors the writer's resolution exactly
-// (evolver-session-end.js#resolveWorkspaceIdForWriter):
+// writer stamps on every memory-graph entry (`workspace_id`). This is the
+// SINGLE source of that resolution: the session-end writer stamps it and the
+// session-start reader scopes by it, so both call this one function. Keeping
+// it here (rather than a copy per hook) is what guarantees reader and writer
+// can never drift apart — if they resolved different ids, no entry would ever
+// match the reader's filter and workspace scoping would silently break.
+// Resolution order:
 //   1. EVOLVER_WORKSPACE_ID env override
 //   2. paths.getWorkspaceId() loaded from the resolved evolver root
 // Returns null when neither is available (e.g. evolver package not installed),

--- a/src/adapters/scripts/evolver-session-end.js
+++ b/src/adapters/scripts/evolver-session-end.js
@@ -170,7 +170,16 @@ function recordToLocal(graphPath, outcome) {
       // .evolver/workspace-id file. cwd is retained as a backward-compat
       // tag so older entries written before this hardening still pass
       // the cwd check.
-      cwd: process.cwd(),
+      //
+      // Use resolveProjectDir() (NOT process.cwd()) so the cwd tag records the
+      // user's project, consistent with how the diff above is collected and
+      // with the session-start reader's cwd fallback. Under Cursor, cwd is the
+      // plugin install dir, so a raw process.cwd() tag would never match the
+      // reader's resolveProjectDir()-derived currentDir — silently hiding every
+      // cwd-only entry (Bugbot PR #555). collect.js only uses cwd as a legacy
+      // fallback (disabled once a workspace_id secret exists), so changing the
+      // tag's source — still a directory path — does not affect its scoping.
+      cwd: resolveProjectDir(),
       workspace_id: resolveWorkspaceId(),
       source: 'hook:session-end',
     };

--- a/src/adapters/scripts/evolver-session-end.js
+++ b/src/adapters/scripts/evolver-session-end.js
@@ -13,27 +13,16 @@ const { spawnSync } = require('child_process');
 // on large repos). See GHSA reports / issue #451.
 const MAX_EXEC_BUFFER = 10 * 1024 * 1024;
 
-const { findEvolverRoot, findMemoryGraph, resolveProjectDir } = require('./_runtimePaths');
+const { findEvolverRoot, findMemoryGraph, resolveProjectDir, resolveWorkspaceId } = require('./_runtimePaths');
 
-// Workspace-id must use the same resolution as the reader in
-// src/evolve/pipeline/collect.js (which goes through src/gep/paths.js#
-// getWorkspaceRoot()). Otherwise writer and reader could land on
-// different `.evolver/workspace-id` files when EVOLVER_REPO_ROOT or
-// OPENCLAW_WORKSPACE is set, or when a `<repoRoot>/workspace`
-// subdirectory exists — in which case the IDs would never match and
-// every memory-graph entry would silently get dropped (Bugbot PR #109
-// round-1 MEDIUM). Lazy-load the canonical resolver from the resolved
-// evolver root; fall back to env-only when paths.js is unreachable.
-function resolveWorkspaceIdForWriter() {
-  if (process.env.EVOLVER_WORKSPACE_ID) return String(process.env.EVOLVER_WORKSPACE_ID);
-  const evolverRoot = findEvolverRoot();
-  if (!evolverRoot) return null;
-  try {
-    const paths = require(path.join(evolverRoot, 'src', 'gep', 'paths.js'));
-    if (typeof paths.getWorkspaceId === 'function') return paths.getWorkspaceId();
-  } catch { /* paths.js unreachable — return null */ }
-  return null;
-}
+// Workspace-id resolution is shared with the session-start reader via
+// _runtimePaths.resolveWorkspaceId(). Reader and writer MUST resolve the SAME
+// id or workspace scoping silently breaks (no entry would ever match the
+// reader's filter), so this logic lives in exactly one place instead of being
+// duplicated here. The shared resolver mirrors src/gep/paths.js#getWorkspaceId()
+// loaded from the evolver root, with an EVOLVER_WORKSPACE_ID env override —
+// consistent with the review-time reader in src/evolve/pipeline/collect.js
+// (Bugbot PR #109 round-1 MEDIUM; reader/writer drift flagged on PR #555).
 
 function runGit(args, cwd) {
   // Argv-array form, no shell. Avoids POSIX `2>/dev/null` redirects that
@@ -182,7 +171,7 @@ function recordToLocal(graphPath, outcome) {
       // tag so older entries written before this hardening still pass
       // the cwd check.
       cwd: process.cwd(),
-      workspace_id: resolveWorkspaceIdForWriter(),
+      workspace_id: resolveWorkspaceId(),
       source: 'hook:session-end',
     };
     fs.appendFileSync(graphPath, JSON.stringify(entry) + '\n', 'utf8');

--- a/src/adapters/scripts/evolver-session-end.js
+++ b/src/adapters/scripts/evolver-session-end.js
@@ -69,11 +69,16 @@ function getGitDiffStats() {
   const filesChanged = (stat.match(/\d+ files? changed/) || ['0'])[0];
   const insertions = (stat.match(/(\d+) insertions?/) || [null, '0'])[1];
   const deletions = (stat.match(/(\d+) deletions?/) || [null, '0'])[1];
+  // Distinguish "no git repo here" from "repo with no changes" purely for the
+  // skip-log message — the diff commands above can't tell the two apart (both
+  // yield empty output). A single cheap rev-parse settles it.
+  const isRepo = runGit(['rev-parse', '--is-inside-work-tree'], cwd).out === 'true';
   return {
     stat,
     summary: `${filesChanged}, +${insertions}/-${deletions}`,
     diffSnippet: diffContent.slice(0, 2000),
     hasChanges: stat.length > 0,
+    isRepo,
   };
 }
 
@@ -187,6 +192,24 @@ function recordToLocal(graphPath, outcome) {
   }
 }
 
+// Append a single timestamped line to ~/.evolver/logs/evolution.log (or
+// EVOLVER_HOOK_LOG_DIR). Best-effort: a log-write failure must never break the
+// hook. Used both for recorded outcomes and for the "skipped, nothing to
+// record" notices so a user can always see why a session did or did not
+// produce an entry.
+function appendEvolutionLog(line) {
+  try {
+    const logDir = process.env.EVOLVER_HOOK_LOG_DIR
+      || path.join(os.homedir(), '.evolver', 'logs');
+    fs.mkdirSync(logDir, { recursive: true });
+    fs.appendFileSync(
+      path.join(logDir, 'evolution.log'),
+      `${new Date().toISOString()} ${line}\n`,
+      'utf8'
+    );
+  } catch { /* best-effort, never break the hook on log write */ }
+}
+
 function main() {
   let inputData = '';
   let handled = false;
@@ -206,6 +229,18 @@ function main() {
       const diffInfo = getGitDiffStats();
 
       if (!diffInfo.hasChanges) {
+        // No git diff means no signal source — session-end derives the
+        // outcome (status/score/signals/summary) entirely from the diff, so
+        // there is nothing meaningful to record. This is expected in a
+        // non-git workspace or a repo with no changes this session. Rather
+        // than fabricate an empty outcome (which would pollute the memory
+        // graph), record nothing — but leave a log breadcrumb so the user
+        // can tell "evolver ran but had nothing to record" apart from
+        // "evolver never fired". (Previously this branch was fully silent.)
+        const reason = diffInfo.isRepo
+          ? 'no changes detected this session'
+          : 'not a git workspace';
+        appendEvolutionLog(`[Evolution] Session end: nothing recorded (${reason}).`);
         finish({});
         return;
       }
@@ -256,16 +291,7 @@ function main() {
       // The receipt is always appended to ~/.evolver/logs/evolution.log
       // so it is never silently lost; users can opt back in to the inline
       // notification with EVOLVER_HOOK_VERBOSE=1.
-      try {
-        const logDir = process.env.EVOLVER_HOOK_LOG_DIR
-          || path.join(os.homedir(), '.evolver', 'logs');
-        fs.mkdirSync(logDir, { recursive: true });
-        fs.appendFileSync(
-          path.join(logDir, 'evolution.log'),
-          `${new Date().toISOString()} ${msg}\n`,
-          'utf8'
-        );
-      } catch { /* best-effort, never break the hook on log write */ }
+      appendEvolutionLog(msg);
 
       finish(isCursorHost() ? {} : { systemMessage: msg });
     } catch (e) {

--- a/src/adapters/scripts/evolver-session-start.js
+++ b/src/adapters/scripts/evolver-session-start.js
@@ -7,17 +7,49 @@ const fs = require('fs');
 const path = require('path');
 const os = require('os');
 
-const { findEvolverRoot, findMemoryGraph } = require('./_runtimePaths');
+const { findEvolverRoot, findMemoryGraph, resolveProjectDir, resolveWorkspaceId } = require('./_runtimePaths');
 const { filterRelevantOutcomes } = require('./_memoryFiltering');
 
-function readLastN(filePath, n) {
+// Parse every entry in the memory graph (newest last). Unlike a tail-N read,
+// we must see all entries BEFORE workspace-scoping: a tail-N-then-filter order
+// would let outcomes from other projects (which share the user-level fallback
+// graph on npm-global installs) crowd out this workspace's entries from the
+// window entirely. Scope first, then take the most recent N downstream.
+function readAllEntries(filePath) {
   try {
     const content = fs.readFileSync(filePath, 'utf8');
-    const lines = content.trim().split('\n').filter(Boolean);
-    return lines.slice(-n).map(line => {
+    return content.trim().split('\n').filter(Boolean).map(line => {
       try { return JSON.parse(line); } catch { return null; }
     }).filter(Boolean);
   } catch { return []; }
+}
+
+// Does this memory-graph entry belong to the current workspace?
+//
+// The session-end writer stamps two tags: `workspace_id` (forge-resistant,
+// preferred) and `cwd` (backward-compat). We scope reads so that one project
+// never sees another's outcomes through the shared user-level fallback graph
+// (~/.evolver/memory/evolution/memory_graph.jsonl) — the cross-project
+// disclosure / prompt-injection surface Bugbot flagged on the writer side
+// (PR #105 round-2), which the reader never enforced until now.
+//
+// Rules, in order:
+//   - currentId known + entry.workspace_id present -> must match exactly.
+//   - currentId unknown OR entry has neither tag (pre-hardening / Hub-sourced
+//     entries) -> do NOT exclude; falling back to "show it" preserves prior
+//     behavior and avoids hiding all memory when ids can't be resolved.
+//   - As a softer fallback, when the entry has no workspace_id but does carry a
+//     cwd, match that against the current project dir.
+function belongsToWorkspace(entry, currentId, currentDir) {
+  if (entry && typeof entry.workspace_id === 'string' && entry.workspace_id) {
+    if (currentId) return entry.workspace_id === currentId;
+    return true; // can't compare — don't hide it
+  }
+  if (entry && typeof entry.cwd === 'string' && entry.cwd) {
+    if (currentDir) return entry.cwd === currentDir;
+    return true;
+  }
+  return true; // untagged (legacy / Hub) — never excluded
 }
 
 function formatOutcome(entry) {
@@ -100,8 +132,17 @@ function main() {
     return;
   }
 
-  const entries = readLastN(graphPath, 5);
-  const filtered = filterRelevantOutcomes(entries);
+  // Scope to the current workspace BEFORE trimming to the most-recent window,
+  // so other projects sharing the user-level fallback graph can't crowd this
+  // workspace's outcomes out of view. When the workspace id can't be resolved,
+  // belongsToWorkspace() falls back to "show it" — no regression vs. the old
+  // unscoped behavior.
+  const currentId = resolveWorkspaceId(evolverRoot);
+  const currentDir = resolveProjectDir();
+  const scoped = readAllEntries(graphPath)
+    .filter(e => belongsToWorkspace(e, currentId, currentDir));
+  const recent = scoped.slice(-5);
+  const filtered = filterRelevantOutcomes(recent);
 
   if (filtered.length === 0) {
     process.stdout.write(JSON.stringify({}));
@@ -125,4 +166,11 @@ function main() {
   }));
 }
 
-main();
+// Run as a hook when invoked directly; expose pure helpers for unit tests when
+// required as a module. Guarding on require.main keeps the direct-execution
+// behavior (the hosts run `node evolver-session-start.js`) unchanged.
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { belongsToWorkspace };
+}

--- a/src/adapters/scripts/evolver-session-start.js
+++ b/src/adapters/scripts/evolver-session-start.js
@@ -10,18 +10,34 @@ const os = require('os');
 const { findEvolverRoot, findMemoryGraph, resolveProjectDir, resolveWorkspaceId } = require('./_runtimePaths');
 const { filterRelevantOutcomes } = require('./_memoryFiltering');
 
-// Parse every entry in the memory graph (newest last). Unlike a tail-N read,
-// we must see all entries BEFORE workspace-scoping: a tail-N-then-filter order
-// would let outcomes from other projects (which share the user-level fallback
-// graph on npm-global installs) crowd out this workspace's entries from the
-// window entirely. Scope first, then take the most recent N downstream.
-function readAllEntries(filePath) {
+// Return up to `n` of the current workspace's most-recent entries, in
+// chronological (oldest-first) order.
+//
+// Why scan from the end: a plain tail-N-then-filter read would let outcomes
+// from other projects (which share the user-level fallback graph on npm-global
+// installs) crowd this workspace's entries out of the window — we must scope
+// to the workspace BEFORE trimming. But parsing the ENTIRE file to do that is
+// wasteful: the graph can reach ~100 MB before rotation, and JSON-parsing every
+// line on each session start is real CPU/memory cost (Bugbot PR #555 round-3).
+//
+// So we read the file (cheap; the previous readLastN read it whole too) but
+// JSON-parse lines lazily from the newest end, keeping only workspace matches,
+// and stop as soon as we have `n`. Parse count is bounded by where this
+// workspace's n-th-most-recent entry sits, not by total file size.
+function readRecentWorkspaceEntries(filePath, currentId, currentDir, n) {
+  let lines;
   try {
-    const content = fs.readFileSync(filePath, 'utf8');
-    return content.trim().split('\n').filter(Boolean).map(line => {
-      try { return JSON.parse(line); } catch { return null; }
-    }).filter(Boolean);
+    lines = fs.readFileSync(filePath, 'utf8').trim().split('\n');
   } catch { return []; }
+  const out = [];
+  for (let i = lines.length - 1; i >= 0 && out.length < n; i--) {
+    const line = lines[i];
+    if (!line) continue;
+    let entry;
+    try { entry = JSON.parse(line); } catch { continue; }
+    if (belongsToWorkspace(entry, currentId, currentDir)) out.push(entry);
+  }
+  return out.reverse(); // newest-collected-first -> chronological
 }
 
 // Does this memory-graph entry belong to the current workspace?
@@ -139,9 +155,7 @@ function main() {
   // unscoped behavior.
   const currentId = resolveWorkspaceId(evolverRoot);
   const currentDir = resolveProjectDir();
-  const scoped = readAllEntries(graphPath)
-    .filter(e => belongsToWorkspace(e, currentId, currentDir));
-  const recent = scoped.slice(-5);
+  const recent = readRecentWorkspaceEntries(graphPath, currentId, currentDir, 5);
   const filtered = filterRelevantOutcomes(recent);
 
   if (filtered.length === 0) {

--- a/test/sessionEndHook.test.js
+++ b/test/sessionEndHook.test.js
@@ -251,3 +251,44 @@ describe('evolver-session-end no-changes log breadcrumb', () => {
     } finally { cleanup(repo); cleanup(home); }
   });
 });
+
+describe('evolver-session-end cwd tag consistency (reader/writer match)', () => {
+  // Regression (Bugbot PR #555 round-2): the writer must stamp the entry's
+  // `cwd` with resolveProjectDir() — the SAME resolver the session-start
+  // reader uses for its cwd fallback — not raw process.cwd(). Under Cursor the
+  // hook's process.cwd() is the plugin install dir, so a raw-cwd tag would
+  // never equal the reader's project-dir-derived currentDir, silently hiding
+  // every cwd-only entry. Force Hub off so the entry lands in local memory.
+  it('tags entry.cwd with CURSOR_PROJECT_DIR, not the hook process cwd', () => {
+    const repo = makeTmpDir();      // user's project, where the diff lives
+    const elsewhere = makeTmpDir(); // simulate Cursor's plugin-dir cwd
+    const home = makeTmpDir();
+    try {
+      initRepoWithDiff(repo);
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      // recordToLocal appends to MEMORY_GRAPH_PATH but does not mkdir for an
+      // explicit path — create the parent the way a real install would.
+      fs.mkdirSync(path.dirname(graph), { recursive: true });
+      const env = baseEnv({
+        HOME: home,
+        EVOLVER_HOOK_LOG_DIR: path.join(home, 'logs'),
+        MEMORY_GRAPH_PATH: graph,
+        TERM_PROGRAM: 'cursor',         // Cursor host
+        CURSOR_PROJECT_DIR: repo,       // real project dir
+        // Hub off so recordToLocal runs and we can inspect the entry.
+        EVOMAP_API_KEY: '', A2A_NODE_SECRET: '', EVOMAP_NODE_ID: '', A2A_NODE_ID: '',
+      });
+
+      const result = runHook(env, elsewhere); // process.cwd() = plugin-ish dir
+      assert.deepEqual(result, {}, 'Cursor host suppresses systemMessage');
+
+      assert.ok(fs.existsSync(graph), 'a local memory entry should be written');
+      const last = fs.readFileSync(graph, 'utf8').trim().split('\n').filter(Boolean).pop();
+      const entry = JSON.parse(last);
+      assert.equal(entry.cwd, repo,
+        `entry.cwd must be the project dir (${repo}), got ${entry.cwd}`);
+      assert.notEqual(entry.cwd, elsewhere,
+        'entry.cwd must NOT be the hook process cwd (the plugin dir under Cursor)');
+    } finally { cleanup(repo); cleanup(elsewhere); cleanup(home); }
+  });
+});

--- a/test/sessionEndHook.test.js
+++ b/test/sessionEndHook.test.js
@@ -197,3 +197,57 @@ describe('evolver-session-end project-dir resolution', () => {
     } finally { cleanup(repo); cleanup(elsewhere); cleanup(home); }
   });
 });
+
+describe('evolver-session-end no-changes log breadcrumb', () => {
+  // A non-git workspace has no diff -> no signal source -> nothing is recorded
+  // (recording an empty outcome would pollute the memory graph). But the hook
+  // must not be fully silent: it logs a one-line skip notice so a user can tell
+  // "ran but had nothing to record" from "never fired".
+  it('logs a "not a git workspace" skip notice and records no outcome', () => {
+    const nongit = makeTmpDir(); // plain dir, no git init
+    const home = makeTmpDir();
+    try {
+      const logDir = path.join(home, 'logs');
+      const env = baseEnv({ HOME: home, EVOLVER_HOOK_LOG_DIR: logDir, TERM_PROGRAM: 'xterm' });
+      delete env.CURSOR_TRACE_ID;
+      delete env.CURSOR_SESSION_ID;
+
+      const result = runHook(env, nongit);
+      assert.deepEqual(result, {}, 'no outcome should be emitted in a non-git workspace');
+
+      const logFile = path.join(logDir, 'evolution.log');
+      assert.ok(fs.existsSync(logFile), 'a skip breadcrumb must be logged');
+      const log = fs.readFileSync(logFile, 'utf8');
+      assert.match(log, /nothing recorded \(not a git workspace\)/);
+      // And it must NOT have written a memory-graph entry.
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      assert.ok(!fs.existsSync(graph) || fs.readFileSync(graph, 'utf8').trim() === '',
+        'no memory-graph entry should be written when there are no changes');
+    } finally { cleanup(nongit); cleanup(home); }
+  });
+
+  it('logs a "no changes detected" notice in a clean git repo', () => {
+    const repo = makeTmpDir();
+    const home = makeTmpDir();
+    try {
+      // git repo with a committed file but NO uncommitted change this session.
+      execSync('git init -q', { cwd: repo });
+      execSync('git config user.email test@example.com', { cwd: repo });
+      execSync('git config user.name test', { cwd: repo });
+      fs.writeFileSync(path.join(repo, 'a.txt'), 'hello\n');
+      execSync('git add a.txt', { cwd: repo });
+      execSync('git commit -q -m initial', { cwd: repo });
+      // No second commit and no edit -> diff HEAD~1 fails, working tree clean.
+
+      const logDir = path.join(home, 'logs');
+      const env = baseEnv({ HOME: home, EVOLVER_HOOK_LOG_DIR: logDir, TERM_PROGRAM: 'xterm' });
+      delete env.CURSOR_TRACE_ID;
+      delete env.CURSOR_SESSION_ID;
+
+      const result = runHook(env, repo);
+      assert.deepEqual(result, {});
+      const log = fs.readFileSync(path.join(logDir, 'evolution.log'), 'utf8');
+      assert.match(log, /nothing recorded \(no changes detected this session\)/);
+    } finally { cleanup(repo); cleanup(home); }
+  });
+});

--- a/test/sessionStartScope.test.js
+++ b/test/sessionStartScope.test.js
@@ -1,0 +1,155 @@
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execFileSync } = require('child_process');
+
+const repoRoot = path.resolve(__dirname, '..');
+const scriptPath = path.join(repoRoot, 'src', 'adapters', 'scripts', 'evolver-session-start.js');
+
+function makeTmpDir() {
+  return fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-sstart-scope-')));
+}
+function cleanup(dir) {
+  try { fs.rmSync(dir, { recursive: true, force: true }); } catch {}
+}
+
+// Build a memory graph file with the given entries (one JSON object per line).
+function writeGraph(file, entries) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, entries.map(e => JSON.stringify(e)).join('\n') + '\n');
+}
+
+// A "good" recent successful outcome that passes filterRelevantOutcomes
+// (status success, score >= 0.5, timestamped now), tagged with a workspace.
+function outcome(note, { workspace_id, cwd } = {}) {
+  const e = {
+    timestamp: new Date().toISOString(),
+    gene_id: 'ad_hoc',
+    signals: ['stable_success_plateau'],
+    outcome: { status: 'success', score: 0.8, note },
+  };
+  if (workspace_id !== undefined) e.workspace_id = workspace_id;
+  if (cwd !== undefined) e.cwd = cwd;
+  return e;
+}
+
+function runStart(env) {
+  const out = execFileSync('node', [scriptPath], {
+    env: { PATH: process.env.PATH, ...env },
+    input: '{}',
+    encoding: 'utf8',
+    timeout: 15000,
+  });
+  try { return JSON.parse(out); } catch { return null; }
+}
+
+function baseEnv(extra) {
+  return {
+    HOME: extra.HOME,
+    EVOLVER_ROOT: repoRoot,
+    // Force dedup off (default) so every run injects.
+    EVOLVER_SESSION_START_DEDUP: '',
+    ...extra,
+  };
+}
+
+describe('evolver-session-start workspace scoping', () => {
+  it('injects only the current workspace\'s outcomes, not other projects\'', () => {
+    const home = makeTmpDir();
+    try {
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      // 6 entries from "other" workspace, then 1 from "mine". A tail-5 read
+      // would miss "mine" entirely; scope-first must surface it.
+      const entries = [];
+      for (let i = 0; i < 6; i++) entries.push(outcome(`other-${i}`, { workspace_id: 'ws-other' }));
+      entries.push(outcome('mine-1', { workspace_id: 'ws-mine' }));
+      writeGraph(graph, entries);
+
+      const env = baseEnv({
+        HOME: home,
+        MEMORY_GRAPH_PATH: graph,
+        EVOLVER_WORKSPACE_ID: 'ws-mine',
+      });
+      const result = runStart(env);
+      assert.ok(result && typeof result.additionalContext === 'string',
+        `expected an injection, got ${JSON.stringify(result)}`);
+      assert.match(result.additionalContext, /mine-1/, 'must include current workspace outcome');
+      assert.doesNotMatch(result.additionalContext, /other-/,
+        'must NOT leak other workspace outcomes');
+    } finally { cleanup(home); }
+  });
+
+  it('emits nothing when only other workspaces have outcomes', () => {
+    const home = makeTmpDir();
+    try {
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      writeGraph(graph, [outcome('other', { workspace_id: 'ws-other' })]);
+      const env = baseEnv({ HOME: home, MEMORY_GRAPH_PATH: graph, EVOLVER_WORKSPACE_ID: 'ws-mine' });
+      const result = runStart(env);
+      assert.deepEqual(result, {}, `expected empty (no own outcomes), got ${JSON.stringify(result)}`);
+    } finally { cleanup(home); }
+  });
+
+  // belongsToWorkspace is the scoping predicate. Unit-test its branches
+  // directly (deterministic) — the end-to-end tests above cover the wired path.
+  describe('belongsToWorkspace predicate', () => {
+    const { belongsToWorkspace } = require('../src/adapters/scripts/evolver-session-start');
+
+    it('unresolved current id -> tagged entries are NOT hidden (no regression)', () => {
+      assert.equal(belongsToWorkspace({ workspace_id: 'ws-other' }, null, null), true);
+    });
+    it('resolved id -> exact match required', () => {
+      assert.equal(belongsToWorkspace({ workspace_id: 'ws-mine' }, 'ws-mine', null), true);
+      assert.equal(belongsToWorkspace({ workspace_id: 'ws-other' }, 'ws-mine', null), false);
+    });
+    it('untagged legacy entry -> always included', () => {
+      assert.equal(belongsToWorkspace({}, 'ws-mine', '/some/dir'), true);
+    });
+    it('cwd fallback when no workspace_id', () => {
+      assert.equal(belongsToWorkspace({ cwd: '/p' }, null, '/p'), true);
+      assert.equal(belongsToWorkspace({ cwd: '/q' }, null, '/p'), false);
+    });
+  });
+
+  it('passes through legacy entries that carry no workspace tag', () => {
+    const home = makeTmpDir();
+    try {
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      // Untagged legacy entry (pre-hardening) + a tagged other-workspace one.
+      writeGraph(graph, [outcome('legacy'), outcome('other', { workspace_id: 'ws-other' })]);
+      const env = baseEnv({ HOME: home, MEMORY_GRAPH_PATH: graph, EVOLVER_WORKSPACE_ID: 'ws-mine' });
+      const result = runStart(env);
+      assert.ok(result && typeof result.additionalContext === 'string');
+      assert.match(result.additionalContext, /legacy/, 'untagged legacy entries must not be hidden');
+      assert.doesNotMatch(result.additionalContext, /other/, 'tagged other-workspace entry still excluded');
+    } finally { cleanup(home); }
+  });
+
+  it('matches on cwd when an entry has cwd but no workspace_id', () => {
+    const home = makeTmpDir();
+    const projectDir = makeTmpDir();
+    try {
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      writeGraph(graph, [
+        outcome('mine-cwd', { cwd: projectDir }),
+        outcome('other-cwd', { cwd: path.join(projectDir, 'nope') }),
+      ]);
+      const env = baseEnv({
+        HOME: home,
+        MEMORY_GRAPH_PATH: graph,
+        // id unresolved -> falls to cwd matching; point project dir at ours
+        CURSOR_PROJECT_DIR: projectDir,
+      });
+      delete env.EVOLVER_WORKSPACE_ID;
+      const result = runStart(env);
+      // currentId is null here, so workspace_id-less entries are matched by cwd
+      // only when currentId is null AND we have currentDir. Both entries lack
+      // workspace_id; belongsToWorkspace falls to cwd compare against projectDir.
+      assert.ok(result && typeof result.additionalContext === 'string');
+      assert.match(result.additionalContext, /mine-cwd/);
+      assert.doesNotMatch(result.additionalContext, /other-cwd/);
+    } finally { cleanup(home); cleanup(projectDir); }
+  });
+});

--- a/test/sessionStartScope.test.js
+++ b/test/sessionStartScope.test.js
@@ -81,6 +81,29 @@ describe('evolver-session-start workspace scoping', () => {
     } finally { cleanup(home); }
   });
 
+  it('surfaces this workspace\'s recent entries even behind many newer other-workspace entries', () => {
+    const home = makeTmpDir();
+    try {
+      const graph = path.join(home, '.evolver', 'memory', 'evolution', 'memory_graph.jsonl');
+      // This workspace's entries come FIRST (older), then a large run of other-
+      // workspace entries (newer). A tail-N read would see only 'other'; the
+      // bounded scan-from-end must walk past them to collect ours — without
+      // parsing being capped at N total (it stops at N *matches*, not N lines).
+      const entries = [];
+      entries.push(outcome('mine-old', { workspace_id: 'ws-mine' }));
+      for (let i = 0; i < 200; i++) entries.push(outcome(`other-${i}`, { workspace_id: 'ws-other' }));
+      entries.push(outcome('mine-new', { workspace_id: 'ws-mine' }));
+      writeGraph(graph, entries);
+
+      const env = baseEnv({ HOME: home, MEMORY_GRAPH_PATH: graph, EVOLVER_WORKSPACE_ID: 'ws-mine' });
+      const result = runStart(env);
+      assert.ok(result && typeof result.additionalContext === 'string',
+        `expected an injection, got ${JSON.stringify(result)}`);
+      assert.match(result.additionalContext, /mine-new/, 'most recent own entry must show');
+      assert.doesNotMatch(result.additionalContext, /other-/, 'no other-workspace leak');
+    } finally { cleanup(home); }
+  });
+
   it('emits nothing when only other workspaces have outcomes', () => {
     const home = makeTmpDir();
     try {


### PR DESCRIPTION
## Summary

Two evolution-hook fixes surfaced while validating the Cursor plugin: (1) session-start memory recall leaked outcomes across projects sharing the user-level fallback graph; (2) session-end was fully silent when it had nothing to record.

## What changed

**Fix 1 — workspace-scoped recall (`evolver-session-start.js`, `_runtimePaths.js`)**
- The reader injected the last 5 outcomes with no workspace filter, while the writer already tags each entry with `workspace_id` (forge-resistant) + `cwd` (compat). On npm-global installs all projects share `~/.evolver/memory/evolution/memory_graph.jsonl`, so project A saw project B's outcomes — the cross-project disclosure surface Bugbot flagged on the writer side (PR #105 round-2), never enforced on the reader.
- Add `resolveWorkspaceId()` to `_runtimePaths.js`, mirroring the writer's resolution. Scope entries **before** the most-recent-N window (filtering after a tail-N read would let other projects crowd this workspace out). Untagged legacy/Hub entries and the unresolved-id case fall through to "show it" — no regression, only leakage removed.

**Fix 2 — no-changes breadcrumb (`evolver-session-end.js`)**
- session-end derives the outcome entirely from the git diff; with no diff (non-git workspace, or no changes) there is no signal, so it records nothing rather than fabricating an empty outcome. The branch was fully silent — indistinguishable from "hook never fired". Now logs a one-line breadcrumb to `evolution.log` (`not a git workspace` vs `no changes detected this session`), writing no graph entry. Inline log-append refactored into a shared `appendEvolutionLog()` helper.

No new runtime dependencies.

## How to test

```
node --test test/sessionStartScope.test.js test/sessionEndHook.test.js test/resolveProjectDir.test.js
```

Expected: all pass (24 tests). Covers cross-project isolation, empty/legacy/cwd-fallback cases, the `belongsToWorkspace` predicate, and both no-changes breadcrumb cases.

The pre-existing local test failures (`adapters*`, `paths.test.js #541`, `modelRouter`, `selfPR`, `validator`, `workspaceKeychain`) are environment artifacts — missing un-committed local files (`test/fixtures/*`, `test/helpers/symlink`, `public.manifest.json`) and sandbox/concurrency flakes — present identically on clean origin/main; none touch the changed scripts.

## Risk

Low -- changes only the hook recall scoping and a log line. Recall scoping degrades to prior behavior when the workspace id can't be resolved; the breadcrumb is best-effort and never breaks the hook.

## Self-check

- [x] Tests added or updated to cover the new behavior; full suite passes locally (`node --test test/*.test.js`).

## Related

Follow-up to #554 (Cursor hook project-dir resolution).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hook-only scoping and logging; unresolved workspace id keeps prior “show all” behavior, and log writes remain best-effort.
> 
> **Overview**
> **Session-start** now filters evolution memory by workspace before taking the last five outcomes, so projects sharing `~/.evolver/memory/evolution/memory_graph.jsonl` no longer see each other’s entries. It uses shared **`resolveWorkspaceId()`** in `_runtimePaths.js` (replacing a writer-only duplicate), **`belongsToWorkspace`**, and a backward scan that parses only matching lines from the end of the graph.
> 
> **Session-end** stamps **`cwd`** with **`resolveProjectDir()`** instead of **`process.cwd()`** so Cursor’s plugin-dir cwd matches the reader; when there is no git diff it writes a one-line skip reason to **`evolution.log`** via **`appendEvolutionLog()`** (non-git vs clean repo).
> 
> New tests cover scoping, skip breadcrumbs, and cwd tag consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c985af3f6c39dfa6d48faf539c2682f8232d45b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->