### PR TITLE
fix(hooks): resolve workspace_id via FS fallback when evolver package is absent

### DIFF
--- a/src/adapters/scripts/_runtimePaths.js
+++ b/src/adapters/scripts/_runtimePaths.js
@@ -167,18 +167,22 @@ function _readWsIdGuarded(dir, file) {
 }
 
 function _fsWorkspaceId(projectDir) {
-  const dir = path.join(_fsWorkspaceRoot(projectDir), '.evolver');
-  const file = path.join(dir, 'workspace-id');
-  // Read first, with symlink guards. (lstat the file directly: if it exists we
-  // return; if it's missing _readWsIdGuarded returns null and we create.)
-  const existing = _readWsIdGuarded(dir, file);
-  if (existing) return existing;
-  // If the file exists but the guards rejected it (symlink / bad format),
-  // refuse rather than create-over it.
-  if (fs.lstatSync(file, { throwIfNoEntry: false })) return null;
-  // Missing — create atomically. Refuse a symlinked .evolver dir (O_NOFOLLOW
-  // only guards the final component, not intermediate dirs).
+  // Whole body is wrapped: the documented contract is "returns null on ANY
+  // read/write error" so the session-start/-end hooks degrade gracefully
+  // rather than crash. throwIfNoEntry:false only suppresses ENOENT; EACCES/EIO
+  // and friends still throw, so a bare lstat/mkdir here must not escape
+  // (Bugbot PR #557 round-2 — an unguarded lstat could crash the hook).
   try {
+    const dir = path.join(_fsWorkspaceRoot(projectDir), '.evolver');
+    const file = path.join(dir, 'workspace-id');
+    // Read first, with symlink guards.
+    const existing = _readWsIdGuarded(dir, file);
+    if (existing) return existing;
+    // If the file exists but the guards rejected it (symlink / bad format),
+    // refuse rather than create over it.
+    if (fs.lstatSync(file, { throwIfNoEntry: false })) return null;
+    // Missing — create atomically. Refuse a symlinked .evolver dir (O_NOFOLLOW
+    // only guards the final component, not intermediate dirs).
     const dirStat = fs.lstatSync(dir, { throwIfNoEntry: false });
     if (dirStat && dirStat.isSymbolicLink()) return null;
     fs.mkdirSync(dir, { recursive: true });

--- a/src/adapters/scripts/_runtimePaths.js
+++ b/src/adapters/scripts/_runtimePaths.js
@@ -112,21 +112,31 @@ function resolveProjectDir() {
 }
 
 // Determine the workspace ROOT for a project, mirroring src/gep/paths.js
-// getWorkspaceRoot(): OPENCLAW_WORKSPACE override, else the git repo root at or
-// above `projectDir`, else `projectDir` itself. Kept in sync so the FS-only
-// fallback below lands its secret file at the SAME path paths.js would, which
-// is what lets an installed @evomap/evolver later read the very same id.
+// getWorkspaceRoot() step-for-step so the FS-only fallback lands its secret at
+// the SAME path paths.js would (what lets an installed @evomap/evolver read the
+// very same id):
+//   1. OPENCLAW_WORKSPACE override.
+//   2. else the git repo root at/above projectDir, BUT if that repo root has a
+//      `workspace/` subdirectory, paths.js returns <repoRoot>/workspace — so we
+//      must too, or the two land on different .evolver/workspace-id files (the
+//      "read back identically" guarantee would break for such projects).
+//   3. else projectDir.
 function _fsWorkspaceRoot(projectDir) {
   if (process.env.OPENCLAW_WORKSPACE) return process.env.OPENCLAW_WORKSPACE;
-  // Walk up from projectDir looking for a .git entry (file or dir).
+  // Walk up from projectDir looking for a .git entry (file or dir) = repo root.
+  let repoRoot = null;
   let dir = projectDir;
   while (dir) {
-    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    if (fs.existsSync(path.join(dir, '.git'))) { repoRoot = dir; break; }
     const parent = path.dirname(dir);
     if (parent === dir) break;
     dir = parent;
   }
-  return projectDir;
+  if (!repoRoot) return projectDir;
+  // Mirror getWorkspaceRoot()'s workspace/ subdir step.
+  const workspaceDir = path.join(repoRoot, 'workspace');
+  if (fs.existsSync(workspaceDir)) return workspaceDir;
+  return repoRoot;
 }
 
 // FS-only re-implementation of src/gep/paths.js getWorkspaceId() for the case
@@ -138,21 +148,34 @@ function _fsWorkspaceRoot(projectDir) {
 // is transparently picked up by paths.getWorkspaceId() once the package is
 // present, and vice-versa. Returns null on any read/write error (caller then
 // falls back to legacy cwd-tag matching — no regression).
-function _fsWorkspaceId(projectDir) {
-  const dir = path.join(_fsWorkspaceRoot(projectDir), '.evolver');
-  const file = path.join(dir, 'workspace-id');
-  // Read first, with the same symlink guards paths.js uses.
+// Read <dir>/workspace-id with the same symlink guards paths.js'
+// _readWorkspaceIdFromFs uses: reject a symlinked .evolver dir, reject a
+// symlinked / non-regular id file, and require hex format. Returns the id, or
+// null on any error / missing file. Used for BOTH the initial read and the
+// EEXIST race re-read so a symlink swapped in between our lstat and openSync
+// can never be followed (Bugbot PR #557).
+function _readWsIdGuarded(dir, file) {
   try {
     const dirStat = fs.lstatSync(dir, { throwIfNoEntry: false });
     if (dirStat && dirStat.isSymbolicLink()) return null;
     const fileStat = fs.lstatSync(file, { throwIfNoEntry: false });
-    if (fileStat) {
-      if (fileStat.isSymbolicLink() || !fileStat.isFile()) return null;
-      const raw = fs.readFileSync(file, 'utf8').trim();
-      if (raw && /^[a-f0-9]{32,}$/i.test(raw)) return raw;
-      return null;
-    }
+    if (!fileStat) return null;
+    if (fileStat.isSymbolicLink() || !fileStat.isFile()) return null;
+    const raw = fs.readFileSync(file, 'utf8').trim();
+    return raw && /^[a-f0-9]{32,}$/i.test(raw) ? raw : null;
   } catch { return null; }
+}
+
+function _fsWorkspaceId(projectDir) {
+  const dir = path.join(_fsWorkspaceRoot(projectDir), '.evolver');
+  const file = path.join(dir, 'workspace-id');
+  // Read first, with symlink guards. (lstat the file directly: if it exists we
+  // return; if it's missing _readWsIdGuarded returns null and we create.)
+  const existing = _readWsIdGuarded(dir, file);
+  if (existing) return existing;
+  // If the file exists but the guards rejected it (symlink / bad format),
+  // refuse rather than create-over it.
+  if (fs.lstatSync(file, { throwIfNoEntry: false })) return null;
   // Missing — create atomically. Refuse a symlinked .evolver dir (O_NOFOLLOW
   // only guards the final component, not intermediate dirs).
   try {
@@ -166,13 +189,10 @@ function _fsWorkspaceId(projectDir) {
     try {
       fd = fs.openSync(file, flags, 0o600);
     } catch (e) {
-      if (e && e.code === 'EEXIST') {
-        // Lost a race — re-read.
-        try {
-          const raw = fs.readFileSync(file, 'utf8').trim();
-          return raw && /^[a-f0-9]{32,}$/i.test(raw) ? raw : null;
-        } catch { return null; }
-      }
+      // Lost a race — re-read WITH the same symlink guards (paths.js does the
+      // same). A bare readFileSync here would follow a symlink swapped in
+      // after our dir lstat (Bugbot PR #557).
+      if (e && e.code === 'EEXIST') return _readWsIdGuarded(dir, file);
       return null; // ELOOP/EMLINK from O_NOFOLLOW hitting a symlink — refuse.
     }
     try { fs.writeSync(fd, payload + '\n', 0, 'utf8'); } finally { fs.closeSync(fd); }

--- a/src/adapters/scripts/_runtimePaths.js
+++ b/src/adapters/scripts/_runtimePaths.js
@@ -111,6 +111,76 @@ function resolveProjectDir() {
   return process.cwd();
 }
 
+// Determine the workspace ROOT for a project, mirroring src/gep/paths.js
+// getWorkspaceRoot(): OPENCLAW_WORKSPACE override, else the git repo root at or
+// above `projectDir`, else `projectDir` itself. Kept in sync so the FS-only
+// fallback below lands its secret file at the SAME path paths.js would, which
+// is what lets an installed @evomap/evolver later read the very same id.
+function _fsWorkspaceRoot(projectDir) {
+  if (process.env.OPENCLAW_WORKSPACE) return process.env.OPENCLAW_WORKSPACE;
+  // Walk up from projectDir looking for a .git entry (file or dir).
+  let dir = projectDir;
+  while (dir) {
+    if (fs.existsSync(path.join(dir, '.git'))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return projectDir;
+}
+
+// FS-only re-implementation of src/gep/paths.js getWorkspaceId() for the case
+// where the evolver package is not installed (plugin-only installs). It reads
+// — and lazily, atomically creates — the per-workspace secret at
+// <workspaceRoot>/.evolver/workspace-id. The format (16-byte hex), the path,
+// the 0600 mode, the O_EXCL|O_NOFOLLOW atomic create, and the symlink
+// rejection all match paths.js exactly, so a workspace seeded by this fallback
+// is transparently picked up by paths.getWorkspaceId() once the package is
+// present, and vice-versa. Returns null on any read/write error (caller then
+// falls back to legacy cwd-tag matching — no regression).
+function _fsWorkspaceId(projectDir) {
+  const dir = path.join(_fsWorkspaceRoot(projectDir), '.evolver');
+  const file = path.join(dir, 'workspace-id');
+  // Read first, with the same symlink guards paths.js uses.
+  try {
+    const dirStat = fs.lstatSync(dir, { throwIfNoEntry: false });
+    if (dirStat && dirStat.isSymbolicLink()) return null;
+    const fileStat = fs.lstatSync(file, { throwIfNoEntry: false });
+    if (fileStat) {
+      if (fileStat.isSymbolicLink() || !fileStat.isFile()) return null;
+      const raw = fs.readFileSync(file, 'utf8').trim();
+      if (raw && /^[a-f0-9]{32,}$/i.test(raw)) return raw;
+      return null;
+    }
+  } catch { return null; }
+  // Missing — create atomically. Refuse a symlinked .evolver dir (O_NOFOLLOW
+  // only guards the final component, not intermediate dirs).
+  try {
+    const dirStat = fs.lstatSync(dir, { throwIfNoEntry: false });
+    if (dirStat && dirStat.isSymbolicLink()) return null;
+    fs.mkdirSync(dir, { recursive: true });
+    const payload = require('crypto').randomBytes(16).toString('hex');
+    const flags = fs.constants.O_WRONLY | fs.constants.O_CREAT | fs.constants.O_EXCL |
+      (fs.constants.O_NOFOLLOW || 0);
+    let fd;
+    try {
+      fd = fs.openSync(file, flags, 0o600);
+    } catch (e) {
+      if (e && e.code === 'EEXIST') {
+        // Lost a race — re-read.
+        try {
+          const raw = fs.readFileSync(file, 'utf8').trim();
+          return raw && /^[a-f0-9]{32,}$/i.test(raw) ? raw : null;
+        } catch { return null; }
+      }
+      return null; // ELOOP/EMLINK from O_NOFOLLOW hitting a symlink — refuse.
+    }
+    try { fs.writeSync(fd, payload + '\n', 0, 'utf8'); } finally { fs.closeSync(fd); }
+    try { fs.chmodSync(file, 0o600); } catch { /* best-effort */ }
+    return payload;
+  } catch { return null; }
+}
+
 // Resolve the current workspace id — the forge-resistant tag the session-end
 // writer stamps on every memory-graph entry (`workspace_id`). This is the
 // SINGLE source of that resolution: the session-end writer stamps it and the
@@ -120,19 +190,26 @@ function resolveProjectDir() {
 // match the reader's filter and workspace scoping would silently break.
 // Resolution order:
 //   1. EVOLVER_WORKSPACE_ID env override
-//   2. paths.getWorkspaceId() loaded from the resolved evolver root
-// Returns null when neither is available (e.g. evolver package not installed),
-// in which case callers must NOT filter — falling back to "show everything"
-// preserves prior behavior rather than hiding all memory on a resolution miss.
-function resolveWorkspaceId(evolverRoot) {
+//   2. paths.getWorkspaceId() loaded from the resolved evolver root (this is
+//      the richer path — it can additionally back the secret with the OS
+//      keychain when @napi-rs/keyring is installed).
+//   3. FS-only fallback for plugin-only installs where the evolver package is
+//      not reachable. Without this, plugin users got workspace_id=null and the
+//      forge-resistant scoping silently degraded to cwd-tag matching (found
+//      via real-Cursor end-to-end testing). The fallback writes the same
+//      secret file paths.js uses, so installing the package later is seamless.
+// Still returns null if even the FS write fails — callers must then NOT filter
+// (show everything), preserving prior behavior rather than hiding all memory.
+function resolveWorkspaceId(evolverRoot, projectDir) {
   if (process.env.EVOLVER_WORKSPACE_ID) return String(process.env.EVOLVER_WORKSPACE_ID);
   const root = evolverRoot || findEvolverRoot();
-  if (!root) return null;
-  try {
-    const paths = require(path.join(root, 'src', 'gep', 'paths.js'));
-    if (typeof paths.getWorkspaceId === 'function') return paths.getWorkspaceId();
-  } catch { /* paths.js unreachable — return null */ }
-  return null;
+  if (root) {
+    try {
+      const paths = require(path.join(root, 'src', 'gep', 'paths.js'));
+      if (typeof paths.getWorkspaceId === 'function') return paths.getWorkspaceId();
+    } catch { /* paths.js unreachable — fall through to FS-only */ }
+  }
+  return _fsWorkspaceId(projectDir || resolveProjectDir());
 }
 
 // Returns a path to the evolution memory graph, or a fallback location that

--- a/src/adapters/scripts/evolver-session-end.js
+++ b/src/adapters/scripts/evolver-session-end.js
@@ -148,6 +148,10 @@ function recordToHub(outcome) {
 
 function recordToLocal(graphPath, outcome) {
   try {
+    // Resolve the project dir once so the cwd tag and the workspace_id secret
+    // share a single, consistent source (both must agree with the session-start
+    // reader's resolveProjectDir()-based scoping).
+    const projectDir = resolveProjectDir();
     const entry = {
       timestamp: new Date().toISOString(),
       gene_id: outcome.geneId || 'ad_hoc',
@@ -179,8 +183,8 @@ function recordToLocal(graphPath, outcome) {
       // cwd-only entry (Bugbot PR #555). collect.js only uses cwd as a legacy
       // fallback (disabled once a workspace_id secret exists), so changing the
       // tag's source — still a directory path — does not affect its scoping.
-      cwd: resolveProjectDir(),
-      workspace_id: resolveWorkspaceId(),
+      cwd: projectDir,
+      workspace_id: resolveWorkspaceId(undefined, projectDir),
       source: 'hook:session-end',
     };
     fs.appendFileSync(graphPath, JSON.stringify(entry) + '\n', 'utf8');

--- a/src/adapters/scripts/evolver-session-start.js
+++ b/src/adapters/scripts/evolver-session-start.js
@@ -153,8 +153,8 @@ function main() {
   // workspace's outcomes out of view. When the workspace id can't be resolved,
   // belongsToWorkspace() falls back to "show it" — no regression vs. the old
   // unscoped behavior.
-  const currentId = resolveWorkspaceId(evolverRoot);
   const currentDir = resolveProjectDir();
+  const currentId = resolveWorkspaceId(evolverRoot, currentDir);
   const recent = readRecentWorkspaceEntries(graphPath, currentId, currentDir, 5);
   const filtered = filterRelevantOutcomes(recent);
 

--- a/test/resolveWorkspaceId.test.js
+++ b/test/resolveWorkspaceId.test.js
@@ -135,4 +135,26 @@ describe('resolveWorkspaceId FS-only fallback', () => {
         'must not write the secret into the symlink target');
     } finally { cleanup(proj); cleanup(evil); }
   });
+
+  // root ignores file permissions, so the EACCES path can't be provoked there.
+  const denyIt = (typeof process.getuid === 'function' && process.getuid() === 0) ? it.skip : it;
+  denyIt('returns null (does not throw) on a filesystem error like EACCES', () => {
+    const repo = makeTmpDir();
+    const evo = path.join(repo, '.evolver');
+    try {
+      // An unreadable/untraversable .evolver makes lstat on the id file throw
+      // EACCES (not ENOENT). The contract is "return null on any error" so the
+      // hook degrades instead of crashing (Bugbot PR #557 round-2 Medium).
+      fs.mkdirSync(evo, { recursive: true });
+      fs.writeFileSync(path.join(evo, 'workspace-id'), 'x');
+      fs.chmodSync(evo, 0o000);
+      let result, threw = false;
+      try { result = resolveWorkspaceId(NO_PKG, repo); } catch { threw = true; }
+      assert.equal(threw, false, 'must not throw on EACCES');
+      assert.equal(result, null, 'must return null on EACCES');
+    } finally {
+      try { fs.chmodSync(evo, 0o755); } catch {}
+      cleanup(repo);
+    }
+  });
 });

--- a/test/resolveWorkspaceId.test.js
+++ b/test/resolveWorkspaceId.test.js
@@ -1,0 +1,109 @@
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const path = require('path');
+const fs = require('fs');
+const os = require('os');
+const { execSync } = require('child_process');
+
+// resolveWorkspaceId resolves the forge-resistant workspace_id tag. When the
+// @evomap/evolver package is unreachable (plugin-only installs), it must still
+// produce a stable id via the FS-only fallback — writing the SAME secret file
+// (<workspaceRoot>/.evolver/workspace-id) that src/gep/paths.js#getWorkspaceId
+// uses, so an installed package picks up the identical id. Regression for the
+// real-Cursor finding where plugin installs got workspace_id=null and scoping
+// silently degraded to cwd matching.
+const { resolveWorkspaceId } = require('../src/adapters/scripts/_runtimePaths');
+const NO_PKG = '/nonexistent-evolver-root-xyz'; // forces the FS-only path
+
+// git-init each tmp dir so it is its OWN workspace root. Without this, the
+// repo-root walk in _fsWorkspaceRoot climbs past the tmp dir to any ancestor
+// .git — and Aurora's /tmp carries a stray /tmp/.git that would otherwise
+// capture the secret (see memory: paths.test.js /tmp/.git flake). A real user
+// project is a git repo anyway, so this matches reality.
+function makeTmpDir() {
+  const d = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-wsid-test-')));
+  execSync('git init -q', { cwd: d });
+  return d;
+}
+function cleanup(dir) { try { fs.rmSync(dir, { recursive: true, force: true }); } catch {} }
+
+describe('resolveWorkspaceId FS-only fallback', () => {
+  let saved;
+  beforeEach(() => {
+    saved = { id: process.env.EVOLVER_WORKSPACE_ID, ws: process.env.OPENCLAW_WORKSPACE };
+    delete process.env.EVOLVER_WORKSPACE_ID;
+    delete process.env.OPENCLAW_WORKSPACE;
+  });
+  afterEach(() => {
+    for (const [k, v] of [['EVOLVER_WORKSPACE_ID', saved.id], ['OPENCLAW_WORKSPACE', saved.ws]]) {
+      if (v === undefined) delete process.env[k]; else process.env[k] = v;
+    }
+  });
+
+  it('EVOLVER_WORKSPACE_ID override wins, no file written', () => {
+    const proj = makeTmpDir();
+    try {
+      process.env.EVOLVER_WORKSPACE_ID = 'override-id-123';
+      assert.equal(resolveWorkspaceId(NO_PKG, proj), 'override-id-123');
+      assert.ok(!fs.existsSync(path.join(proj, '.evolver', 'workspace-id')),
+        'override must not trigger a file write');
+    } finally { cleanup(proj); }
+  });
+
+  it('generates a stable hex id and persists it at <root>/.evolver/workspace-id', () => {
+    const proj = makeTmpDir();
+    try {
+      const id1 = resolveWorkspaceId(NO_PKG, proj);
+      assert.match(id1, /^[a-f0-9]{32,}$/i, `id must be hex, got ${id1}`);
+      const file = path.join(proj, '.evolver', 'workspace-id');
+      assert.ok(fs.existsSync(file), 'secret file must be created');
+      assert.equal(fs.statSync(file).mode & 0o777, 0o600, 'secret file must be 0600');
+      // Second call re-reads the same id (lazy create is stable).
+      assert.equal(resolveWorkspaceId(NO_PKG, proj), id1, 'id must be stable across calls');
+    } finally { cleanup(proj); }
+  });
+
+  it('two different project dirs get different ids (isolation)', () => {
+    const a = makeTmpDir(); const b = makeTmpDir();
+    try {
+      assert.notEqual(resolveWorkspaceId(NO_PKG, a), resolveWorkspaceId(NO_PKG, b));
+    } finally { cleanup(a); cleanup(b); }
+  });
+
+  it('resolves the git repo ROOT, not a subdir (matches paths.js getWorkspaceRoot)', () => {
+    const repo = makeTmpDir();
+    try {
+      execSync('git init -q', { cwd: repo });
+      const sub = path.join(repo, 'src', 'deep');
+      fs.mkdirSync(sub, { recursive: true });
+      // Called from a subdir, the secret must land at the repo root.
+      const id = resolveWorkspaceId(NO_PKG, sub);
+      assert.match(id, /^[a-f0-9]{32,}$/i);
+      assert.ok(fs.existsSync(path.join(repo, '.evolver', 'workspace-id')),
+        'secret must be at the git repo root, not the subdir');
+      assert.ok(!fs.existsSync(path.join(sub, '.evolver', 'workspace-id')),
+        'secret must NOT be created in the subdir');
+    } finally { cleanup(repo); }
+  });
+
+  it('OPENCLAW_WORKSPACE overrides the workspace root', () => {
+    const ws = makeTmpDir(); const proj = makeTmpDir();
+    try {
+      process.env.OPENCLAW_WORKSPACE = ws;
+      resolveWorkspaceId(NO_PKG, proj);
+      assert.ok(fs.existsSync(path.join(ws, '.evolver', 'workspace-id')),
+        'secret must land at OPENCLAW_WORKSPACE root');
+    } finally { cleanup(ws); cleanup(proj); }
+  });
+
+  it('refuses a symlinked .evolver dir (returns null, no write through link)', () => {
+    const proj = makeTmpDir(); const evil = makeTmpDir();
+    try {
+      fs.symlinkSync(evil, path.join(proj, '.evolver'));
+      assert.equal(resolveWorkspaceId(NO_PKG, proj), null,
+        'must refuse to resolve through a symlinked .evolver dir');
+      assert.ok(!fs.existsSync(path.join(evil, 'workspace-id')),
+        'must not write the secret into the symlink target');
+    } finally { cleanup(proj); cleanup(evil); }
+  });
+});

--- a/test/resolveWorkspaceId.test.js
+++ b/test/resolveWorkspaceId.test.js
@@ -96,6 +96,35 @@ describe('resolveWorkspaceId FS-only fallback', () => {
     } finally { cleanup(ws); cleanup(proj); }
   });
 
+  it('lands the secret under <repoRoot>/workspace when that subdir exists (paths.js parity)', () => {
+    // paths.js getWorkspaceRoot() returns <repoRoot>/workspace if present, so
+    // the fallback must too — otherwise an installed package reads a different
+    // file and the "read back identically" guarantee breaks (Bugbot PR #557).
+    const repo = makeTmpDir();
+    try {
+      fs.mkdirSync(path.join(repo, 'workspace'), { recursive: true });
+      const id = resolveWorkspaceId(NO_PKG, repo);
+      assert.match(id, /^[a-f0-9]{32,}$/i);
+      assert.ok(fs.existsSync(path.join(repo, 'workspace', '.evolver', 'workspace-id')),
+        'secret must live under <repoRoot>/workspace/.evolver');
+      assert.ok(!fs.existsSync(path.join(repo, '.evolver', 'workspace-id')),
+        'secret must NOT be written at <repoRoot>/.evolver when workspace/ exists');
+    } finally { cleanup(repo); }
+  });
+
+  it('refuses a pre-existing symlinked id FILE rather than following it', () => {
+    const proj = makeTmpDir(); const evil = makeTmpDir();
+    try {
+      const evoDir = path.join(proj, '.evolver');
+      fs.mkdirSync(evoDir, { recursive: true });
+      const target = path.join(evil, 'attacker-id');
+      fs.writeFileSync(target, 'deadbeef'.repeat(4) + '\n');
+      fs.symlinkSync(target, path.join(evoDir, 'workspace-id'));
+      assert.equal(resolveWorkspaceId(NO_PKG, proj), null,
+        'a symlinked workspace-id file must be refused, not followed');
+    } finally { cleanup(proj); cleanup(evil); }
+  });
+
   it('refuses a symlinked .evolver dir (returns null, no write through link)', () => {
     const proj = makeTmpDir(); const evil = makeTmpDir();
     try {


### PR DESCRIPTION
## Summary

Real-Cursor end-to-end testing of the plugin revealed that on plugin-only installs (no `@evomap/evolver` package present), `resolveWorkspaceId` returned `null` — so session-end stamped `workspace_id: null` and the forge-resistant workspace scoping silently degraded to plain `cwd`-tag matching.

## What changed

- Add an FS-only fallback to `_runtimePaths.resolveWorkspaceId`: when the evolver package can't be reached, read — and lazily, atomically create — the per-workspace secret at `<workspaceRoot>/.evolver/workspace-id`.
- It mirrors `src/gep/paths.js#getWorkspaceId` exactly: workspace root (`OPENCLAW_WORKSPACE` → git repo root at/above the project dir → project dir), 16-byte hex format, `0600` mode, `O_EXCL|O_NOFOLLOW` atomic create, symlink rejection on dir and file. **A workspace seeded by the fallback is read back identically by `paths.getWorkspaceId()` once the package is installed** — verified both resolve the same id from the same file.
- `resolveWorkspaceId(evolverRoot, projectDir?)` gains an optional `projectDir`; reader and writer both pass their already-computed `resolveProjectDir()` value so they resolve the secret against the same root.
- Resolution order unchanged in spirit: `EVOLVER_WORKSPACE_ID` → package `getWorkspaceId()` (richer; can use the OS keychain) → FS-only fallback → `null` (caller then shows everything, no regression).

No new runtime dependencies.

## How to test

```
node --test test/resolveWorkspaceId.test.js
```

Expected: 6 pass — env override (no file written), stable hex generation + persistence + 0600, cross-project isolation, git-repo-root resolution, `OPENCLAW_WORKSPACE` override, symlinked-`.evolver` refusal.

End-to-end (simulating Cursor: cwd = plugin dir, `CURSOR_PROJECT_DIR` = a git repo, no evolver package): the written entry now has a non-null `workspace_id`.

Full-suite A/B vs clean origin/main: my changes 15 fail vs base 18 fail — both within the same pre-existing environment-flake band (missing un-committed `test/fixtures/*` / `test/helpers/symlink` / `public.manifest.json`, `/tmp/.git`, sandbox concurrency). All six touched/related test files pass 54/54 when run serially. No new real failures.

## Risk

Low — the fallback only activates when the package is absent; it returns `null` on any FS/symlink error, preserving the prior cwd-fallback behavior. The secret-file format/path is byte-identical to `paths.js`, so installed-package and plugin-only nodes interoperate.

## Self-check

- [x] Tests added or updated to cover the new behavior; full suite passes locally (`node --test test/*.test.js`).

## Related

Follow-up to #554 / #555 (Cursor hook fixes). Surfaced by real-Cursor end-to-end verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Fallback only runs without the package; failures return null (prior behavior). Secret path/format matches paths.js; symlink guards limit filesystem abuse in hooks.
> 
> **Overview**
> Plugin-only installs (no `@evomap/evolver`) previously left **`workspace_id` null** on session-end memory entries, so forge-resistant scoping fell back to **`cwd`** matching and could mis-scope or cross-pollinate shared graphs.
> 
> **`resolveWorkspaceId`** in `_runtimePaths.js` now adds a **third step** after env override and `paths.getWorkspaceId()`: an **FS-only fallback** that mirrors `src/gep/paths.js`—same workspace root rules (`OPENCLAW_WORKSPACE`, git root with optional `workspace/` subdir, else project dir), same `<root>/.evolver/workspace-id` file (hex secret, `0600`, atomic `O_EXCL|O_NOFOLLOW` create), and **symlink / bad-format refusal** with **null on any error** so hooks degrade instead of crashing.
> 
> **Session hooks** pass a shared **`projectDir`** from `resolveProjectDir()` into **`resolveWorkspaceId(evolverRoot, projectDir)`** so session-start filtering and session-end stamping use the same root (important when Cursor’s cwd is the plugin dir).
> 
> New tests in **`test/resolveWorkspaceId.test.js`** cover override, persistence, isolation, git-root/`workspace/` parity, symlink refusal, and EACCES graceful null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9dcfbeed28110716c1b72d4ef23d5402d4b3d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->