### PR TITLE
fix(loop): break Ralph-loop when a bridge-mode pending run goes stale (#556)

### DIFF
--- a/index.js
+++ b/index.js
@@ -492,10 +492,18 @@ async function main() {
         // last_solidify never catches up and the gate would sleep forever. Once a
         // pending run is older than the sub-agent's own hard ceiling it cannot
         // still be running, so we auto-reject it and let the next cycle proceed.
-        // Default = cycleTimeoutMs (fallback to 45 min if the timeout is disabled).
+        //
+        // The default is the cycle hard-ceiling -- but ONLY when that ceiling is
+        // actually enforced. If EVOLVER_CYCLE_TIMEOUT_ENABLED=false (or the
+        // timeout is 0), a sub-agent may legitimately run longer than 45 min, so
+        // there is no safe default age at which a pending run is provably dead;
+        // we default the TTL to 0 (staleness auto-reject OFF) and let the user
+        // opt back in explicitly via EVOLVER_PENDING_STALE_MS. A value of 0
+        // disables the TTL check in the gate below.
+        const cycleCeilingMs = cycleTimeoutEnabled ? cycleTimeoutMs : 0;
         const pendingStaleMs = parseMs(
           process.env.EVOLVER_PENDING_STALE_MS,
-          cycleTimeoutMs > 0 ? cycleTimeoutMs : 2700000
+          cycleCeilingMs
         );
 
         // Start hub heartbeat (keeps node alive independently of evolution cycles)

--- a/index.js
+++ b/index.js
@@ -98,6 +98,60 @@ function isPendingSolidify(state) {
   return String(lastSolid.run_id) !== String(lastRun.run_id);
 }
 
+/**
+ * Age (ms) of the currently-pending run, measured from last_run.created_at.
+ * Returns null when there is no pending run or no parseable timestamp — callers
+ * MUST treat null as "age unknown, do not force-reject" so a malformed/missing
+ * timestamp never causes us to discard a run that a sub-agent is still working.
+ * @param {object} state - parsed evolution_solidify_state.json
+ * @param {number} now - epoch ms (injected for deterministic tests)
+ * @returns {number|null}
+ */
+function pendingRunAgeMs(state, now) {
+  if (!isPendingSolidify(state)) return null;
+  const lastRun = state && state.last_run ? state.last_run : null;
+  const stamp = lastRun && (lastRun.created_at || lastRun.started_at);
+  if (!stamp) return null;
+  const t = Date.parse(String(stamp));
+  if (!Number.isFinite(t)) return null;
+  const age = Number(now) - t;
+  return age >= 0 ? age : null;
+}
+
+/**
+ * Issue #556: auto-reject a pending run that has been waiting longer than the
+ * staleness TTL. In Bridge mode the sub-agent solidifies asynchronously, so a
+ * pending run is normal *while the sub-agent is alive*. But if the sub-agent
+ * produced no changes, crashed, or the daemon restarted onto a stale pending
+ * state, last_solidify never catches up and the Ralph-loop gate sleeps forever.
+ * Once the pending run is older than the sub-agent's own hard ceiling
+ * (cycleTimeoutMs) it cannot still be running, so we clear it. This is distinct
+ * from rejectPendingRun()'s bridge-disabled reason so the two paths stay
+ * auditable in the state file.
+ * @returns {boolean} true if a stale pending run was found and rejected
+ */
+function rejectStalePendingRun(statePath) {
+  try {
+    const state = readJsonSafe(statePath);
+    if (state && state.last_run && state.last_run.run_id) {
+      state.last_solidify = {
+        run_id: state.last_run.run_id,
+        rejected: true,
+        reason: 'stale_pending_no_solidify_autoreject_no_rollback',
+        timestamp: new Date().toISOString(),
+      };
+      const tmp = `${statePath}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(state, null, 2) + '\n', 'utf8');
+      fs.renameSync(tmp, statePath);
+      return true;
+    }
+  } catch (e) {
+    console.warn('[Loop] Failed to clear stale pending run state: ' + (e.message || e));
+  }
+
+  return false;
+}
+
 function parseMs(v, fallback) {
   const n = parseInt(String(v == null ? '' : v), 10);
   if (Number.isFinite(n)) return Math.max(0, n);
@@ -426,6 +480,19 @@ async function main() {
         const cycleTimeoutMs = parseMs(process.env.EVOLVER_CYCLE_TIMEOUT_MS, 2700000); // 45 min default
         const progressUpdateMs = parseMs(process.env.EVOLVER_PROGRESS_UPDATE_MS, 60000); // 1 min default
 
+        // Issue #556: staleness TTL for a pending (un-solidified) run. In Bridge
+        // mode the gate below sleeps while a sub-agent solidifies asynchronously,
+        // which is correct *while the sub-agent is alive*. If the sub-agent made
+        // no changes / crashed / the daemon restarted onto a stale pending state,
+        // last_solidify never catches up and the gate would sleep forever. Once a
+        // pending run is older than the sub-agent's own hard ceiling it cannot
+        // still be running, so we auto-reject it and let the next cycle proceed.
+        // Default = cycleTimeoutMs (fallback to 45 min if the timeout is disabled).
+        const pendingStaleMs = parseMs(
+          process.env.EVOLVER_PENDING_STALE_MS,
+          cycleTimeoutMs > 0 ? cycleTimeoutMs : 2700000
+        );
+
         // Start hub heartbeat (keeps node alive independently of evolution cycles)
         try {
           if (process.env.EVOMAP_PROXY === '1' || process.env.A2A_TRANSPORT === 'mailbox') {
@@ -564,8 +631,26 @@ async function main() {
           // Ralph-loop gating: do not run a new cycle while previous run is pending solidify.
           const st0 = readJsonSafe(solidifyStatePath);
           if (isPendingSolidify(st0)) {
-            await sleepMs(Math.max(pendingSleepMs, minSleepMs));
-            continue;
+            // Issue #556: a pending run that has outlived the sub-agent's hard
+            // ceiling can never be solidified by that sub-agent, so clear it
+            // instead of sleeping forever. This applies in Bridge mode too,
+            // where the bridge-disabled auto-reject below never runs. TTL-gated
+            // so a live sub-agent's in-flight pending state is left untouched.
+            const ageMs = pendingRunAgeMs(st0, Date.now());
+            if (pendingStaleMs > 0 && ageMs !== null && ageMs >= pendingStaleMs) {
+              const cleared = rejectStalePendingRun(solidifyStatePath);
+              if (cleared) {
+                console.warn(
+                  '[Loop] Auto-rejected stale pending run after ' +
+                    Math.round(ageMs / 1000) + 's with no solidify ' +
+                    '(sub-agent did not complete; state only, no rollback). Issue #556.'
+                );
+              }
+              // Fall through to run a fresh cycle this iteration.
+            } else {
+              await sleepMs(Math.max(pendingSleepMs, minSleepMs));
+              continue;
+            }
           }
 
           const t0 = Date.now();
@@ -1944,7 +2029,9 @@ module.exports = {
   main,
   readJsonSafe,
   rejectPendingRun,
+  rejectStalePendingRun,
   isPendingSolidify,
+  pendingRunAgeMs,
   parseBoolEnv,
   CycleTimeoutError,
   writeCycleProgressAtomic,

--- a/index.js
+++ b/index.js
@@ -133,7 +133,12 @@ function pendingRunAgeMs(state, now) {
 function rejectStalePendingRun(statePath) {
   try {
     const state = readJsonSafe(statePath);
-    if (state && state.last_run && state.last_run.run_id) {
+    // Re-check pending status under this fresh read (TOCTOU guard): if the
+    // sub-agent solidified between the gate's age snapshot and now, the run is
+    // no longer pending and we MUST NOT overwrite that successful solidify with
+    // a rejection. isPendingSolidify() is true only when last_run.run_id
+    // exists, so this also subsumes the run_id presence check.
+    if (state && isPendingSolidify(state)) {
       state.last_solidify = {
         run_id: state.last_run.run_id,
         rejected: true,
@@ -637,17 +642,21 @@ async function main() {
             // where the bridge-disabled auto-reject below never runs. TTL-gated
             // so a live sub-agent's in-flight pending state is left untouched.
             const ageMs = pendingRunAgeMs(st0, Date.now());
-            if (pendingStaleMs > 0 && ageMs !== null && ageMs >= pendingStaleMs) {
-              const cleared = rejectStalePendingRun(solidifyStatePath);
-              if (cleared) {
-                console.warn(
-                  '[Loop] Auto-rejected stale pending run after ' +
-                    Math.round(ageMs / 1000) + 's with no solidify ' +
-                    '(sub-agent did not complete; state only, no rollback). Issue #556.'
-                );
-              }
-              // Fall through to run a fresh cycle this iteration.
+            const cleared =
+              pendingStaleMs > 0 && ageMs !== null && ageMs >= pendingStaleMs
+                ? rejectStalePendingRun(solidifyStatePath)
+                : false;
+            if (cleared) {
+              console.warn(
+                '[Loop] Auto-rejected stale pending run after ' +
+                  Math.round(ageMs / 1000) + 's with no solidify ' +
+                  '(sub-agent did not complete; state only, no rollback). Issue #556.'
+              );
+              // Run was cleared (no longer pending) -> fall through to a fresh cycle.
             } else {
+              // Either not stale yet, or the reject did not take (write failed /
+              // solidify won the race). In every such case the run is still
+              // pending, so sleep instead of stacking a new cycle on top of it.
               await sleepMs(Math.max(pendingSleepMs, minSleepMs));
               continue;
             }

--- a/test/loopMode.test.js
+++ b/test/loopMode.test.js
@@ -157,6 +157,28 @@ describe('rejectStalePendingRun (issue #556)', () => {
     fs.writeFileSync(sp, JSON.stringify({}, null, 2));
     assert.equal(rejectStalePendingRun(sp), false);
   });
+
+  it('does NOT overwrite a run that already solidified (TOCTOU guard, Bugbot #559 High)', () => {
+    // If the sub-agent solidifies between the gate's age snapshot and this
+    // write, last_run == last_solidify (not pending) and a rejection would
+    // corrupt a successful solidify. rejectStalePendingRun must re-check
+    // pending status under its own fresh read and refuse.
+    const stateDir = path.join(tmpDir, 'memory', 'evolution');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const sp = path.join(stateDir, 'evolution_solidify_state.json');
+    const solidified = {
+      last_run: { run_id: 'run_done' },
+      last_solidify: { run_id: 'run_done', validation: { ok: true } },
+    };
+    fs.writeFileSync(sp, JSON.stringify(solidified, null, 2));
+
+    const changed = rejectStalePendingRun(sp);
+    const after = JSON.parse(fs.readFileSync(sp, 'utf8'));
+
+    assert.equal(changed, false, 'must not reject an already-solidified run');
+    // The successful solidify is preserved verbatim — not overwritten with a rejection.
+    assert.deepEqual(after.last_solidify, solidified.last_solidify);
+  });
 });
 
 describe('readJsonSafe', () => {

--- a/test/loopMode.test.js
+++ b/test/loopMode.test.js
@@ -3,7 +3,13 @@ const assert = require('node:assert/strict');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { rejectPendingRun, isPendingSolidify, readJsonSafe } = require('../index.js');
+const {
+  rejectPendingRun,
+  rejectStalePendingRun,
+  isPendingSolidify,
+  pendingRunAgeMs,
+  readJsonSafe,
+} = require('../index.js');
 
 const savedEnv = {};
 const envKeys = [
@@ -87,6 +93,69 @@ describe('isPendingSolidify', () => {
       last_run: { run_id: 123 },
       last_solidify: { run_id: '123' },
     }), false);
+  });
+});
+
+describe('pendingRunAgeMs (issue #556)', () => {
+  const NOW = Date.parse('2026-06-03T12:00:00.000Z');
+
+  it('returns null when there is no pending run', () => {
+    assert.equal(pendingRunAgeMs(null, NOW), null);
+    assert.equal(pendingRunAgeMs({}, NOW), null);
+    assert.equal(pendingRunAgeMs({
+      last_run: { run_id: 'r1' },
+      last_solidify: { run_id: 'r1' },
+    }, NOW), null);
+  });
+
+  it('returns null when pending but no parseable timestamp (age unknown -> never force-reject)', () => {
+    assert.equal(pendingRunAgeMs({ last_run: { run_id: 'r1' } }, NOW), null);
+    assert.equal(pendingRunAgeMs({ last_run: { run_id: 'r1', created_at: 'not-a-date' } }, NOW), null);
+  });
+
+  it('computes age from created_at', () => {
+    const created = new Date(NOW - 90 * 1000).toISOString();
+    assert.equal(pendingRunAgeMs({ last_run: { run_id: 'r1', created_at: created } }, NOW), 90 * 1000);
+  });
+
+  it('falls back to started_at when created_at is absent', () => {
+    const started = new Date(NOW - 30 * 1000).toISOString();
+    assert.equal(pendingRunAgeMs({ last_run: { run_id: 'r1', started_at: started } }, NOW), 30 * 1000);
+  });
+
+  it('returns null for a future timestamp (clock skew -> do not force-reject)', () => {
+    const future = new Date(NOW + 60 * 1000).toISOString();
+    assert.equal(pendingRunAgeMs({ last_run: { run_id: 'r1', created_at: future } }, NOW), null);
+  });
+});
+
+describe('rejectStalePendingRun (issue #556)', () => {
+  it('marks a pending run rejected with the stale-specific reason, preserving untracked files', () => {
+    const stateDir = path.join(tmpDir, 'memory', 'evolution');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const sp = path.join(stateDir, 'evolution_solidify_state.json');
+    fs.writeFileSync(sp, JSON.stringify({ last_run: { run_id: 'run_stale' } }, null, 2));
+    fs.writeFileSync(path.join(tmpDir, 'KEEP.md'), 'keep me\n');
+
+    const changed = rejectStalePendingRun(sp);
+    const state = JSON.parse(fs.readFileSync(sp, 'utf8'));
+
+    assert.equal(changed, true);
+    assert.equal(state.last_solidify.run_id, 'run_stale');
+    assert.equal(state.last_solidify.rejected, true);
+    // Distinct reason from rejectPendingRun() so the two paths stay auditable.
+    assert.equal(state.last_solidify.reason, 'stale_pending_no_solidify_autoreject_no_rollback');
+    assert.equal(fs.readFileSync(path.join(tmpDir, 'KEEP.md'), 'utf8'), 'keep me\n');
+    // After rejection the run is no longer pending.
+    assert.equal(isPendingSolidify(state), false);
+  });
+
+  it('returns false when there is no pending run to reject', () => {
+    const stateDir = path.join(tmpDir, 'memory', 'evolution');
+    fs.mkdirSync(stateDir, { recursive: true });
+    const sp = path.join(stateDir, 'evolution_solidify_state.json');
+    fs.writeFileSync(sp, JSON.stringify({}, null, 2));
+    assert.equal(rejectStalePendingRun(sp), false);
   });
 });
 
@@ -287,6 +356,42 @@ describe('loop-mode EVOLVE_BRIDGE default (issue #96)', () => {
     assert.ok(
       /git stash/.test(combined),
       'safety banner must reference git stash recovery: ' + combined.slice(0, 800)
+    );
+  });
+
+  // Issue #556: in bridge=true mode (the default) a pending run that never gets
+  // solidified used to wedge the Ralph-loop gate forever, because the
+  // bridge-disabled auto-reject only runs when EVOLVE_BRIDGE=false. We seed a
+  // stale pending state with an old timestamp and a short staleness TTL, then
+  // confirm the daemon clears it and proceeds rather than sleeping forever.
+  function seedStalePending(ageMs) {
+    const evoDir = path.join(tmpDir, 'memory', 'evolution');
+    fs.mkdirSync(evoDir, { recursive: true });
+    const createdAt = new Date(Date.now() - ageMs).toISOString();
+    fs.writeFileSync(
+      path.join(evoDir, 'evolution_solidify_state.json'),
+      JSON.stringify({ last_run: { run_id: 'run_stuck', created_at: createdAt } }, null, 2)
+    );
+  }
+
+  it('bridge=true: auto-rejects a stale pending run instead of Ralph-looping (#556)', () => {
+    ensureGitRepo(tmpDir);
+    // 10 min old pending run, TTL 1s -> immediately stale on the first gate check.
+    seedStalePending(10 * 60 * 1000);
+    const combined = runDaemonOnce({
+      EVOLVE_BRIDGE: 'true',
+      EVOLVER_PENDING_STALE_MS: '1000',
+    });
+    // The auto-reject log line is the deterministic proof of escape: it is
+    // emitted only when the gate clears the stale run and FALLS THROUGH to run
+    // a fresh cycle. Revert the fix and the gate sleeps pendingSleepMs forever
+    // -> the 30s-timeout daemon is killed and this line never appears. (What
+    // evolve.run() writes to the state file afterward is engine-dependent and
+    // not asserted here; rejectStalePendingRun's state mutation is covered by
+    // its own deterministic unit test above.)
+    assert.ok(
+      /Auto-rejected stale pending run/.test(combined) && /Issue #556/.test(combined),
+      'daemon must auto-reject the stale pending run in bridge mode (not Ralph-loop): ' + combined.slice(0, 800)
     );
   });
 });

--- a/test/loopMode.test.js
+++ b/test/loopMode.test.js
@@ -416,6 +416,33 @@ describe('loop-mode EVOLVE_BRIDGE default (issue #96)', () => {
       'daemon must auto-reject the stale pending run in bridge mode (not Ralph-loop): ' + combined.slice(0, 800)
     );
   });
+
+  it('staleness TTL defaults OFF when the cycle timeout is disabled (Bugbot #559 Medium)', () => {
+    // When EVOLVER_CYCLE_TIMEOUT_ENABLED=false there is no enforced hard ceiling,
+    // so a sub-agent may legitimately run past 45 min. The TTL must NOT default
+    // to 45 min and reject an in-progress solidify. With no explicit
+    // EVOLVER_PENDING_STALE_MS, a stale-looking pending run must be left alone.
+    ensureGitRepo(tmpDir);
+    seedStalePending(60 * 60 * 1000); // 1h old — would trip a 45-min default TTL
+    const combined = runDaemonOnce({
+      EVOLVE_BRIDGE: 'true',
+      EVOLVER_CYCLE_TIMEOUT_ENABLED: 'false',
+      // EVOLVER_PENDING_STALE_MS intentionally unset -> default should be 0 (OFF).
+    });
+    assert.ok(
+      !/Auto-rejected stale pending run/.test(combined),
+      'TTL must be OFF by default when cycle timeout is disabled; must not auto-reject: ' + combined.slice(0, 800)
+    );
+    // The pending run is untouched (still no last_solidify written by us).
+    const sp = path.join(tmpDir, 'memory', 'evolution', 'evolution_solidify_state.json');
+    const state = JSON.parse(fs.readFileSync(sp, 'utf8'));
+    assert.equal(state.last_run && state.last_run.run_id, 'run_stuck');
+    assert.equal(
+      state.last_solidify && state.last_solidify.reason,
+      undefined,
+      'no stale-reject should have been written'
+    );
+  });
 });
 
 describe('bare invocation routing -- black-box', () => {


### PR DESCRIPTION
## Summary

In `--loop` mode (default `EVOLVE_BRIDGE=true` since v1.85.0) a pending evolution run that never gets solidified wedges the daemon in a permanent Ralph-loop. This adds a staleness TTL so the gate clears an orphaned pending run instead of sleeping forever — without disturbing the legitimate async-solidify path.

## What changed

- **Root cause** (as diagnosed by @wangsheng520520 in #556): the Ralph-loop gate (`index.js`) sleeps while `isPendingSolidify()` is true. In bridge mode the sub-agent solidifies asynchronously, so a pending run is *normal while the sub-agent is alive*. But if the sub-agent produces no changes / crashes / the daemon restarts onto a stale pending state, `last_solidify.run_id` never catches up to `last_run.run_id` and the gate sleeps 60s forever. The existing auto-reject safety net only ran under `EVOLVE_BRIDGE=false`, so the **default** path had no escape.
- **Why not the reporter's suggested one-liner** (drop the `=== 'false'` guard so auto-reject runs in all modes): that would unconditionally reject a pending run after *every* `evolve.run()` return — including runs a live sub-agent is still working — re-breaking the #96 "33 days of zero EvolutionEvents" failure mode. Instead this gates the reject on a **staleness TTL**.
- `pendingRunAgeMs(state, now)` — age of the pending run from `last_run.created_at` (falls back to `started_at`). Returns `null` (→ never force-reject) when there is no pending run, no/unparseable timestamp, or a future timestamp (clock skew).
- `rejectStalePendingRun(statePath)` — clears the run with a distinct, auditable reason `stale_pending_no_solidify_autoreject_no_rollback` (no git rollback), kept separate from `rejectPendingRun()`'s bridge-disabled reason.
- Ralph-loop gate: when pending **and** `ageMs >= pendingStaleMs`, clear and fall through to a fresh cycle; otherwise sleep as before. Default TTL = `cycleTimeoutMs` (the sub-agent's own 45-min hard ceiling), overridable via new `EVOLVER_PENDING_STALE_MS`.

## How to test

```bash
node --test test/loopMode.test.js
# 29/29 pass, including:
#   pendingRunAgeMs (issue #556)            — 5 cases
#   rejectStalePendingRun (issue #556)      — 2 cases
#   bridge=true: auto-rejects a stale pending run instead of Ralph-looping (#556)
```

The black-box daemon test seeds a 10-min-old pending run with `EVOLVER_PENDING_STALE_MS=1000` and asserts the daemon logs `Auto-rejected stale pending run … Issue #556` (the line is emitted only when the gate clears the run and falls through). **Verified it fails when the fix is reverted** (gate reverts to sleep-only → daemon Ralph-loops → killed at the 30s test timeout → log line absent), so it's a real regression guard, not a vacuous pass.

Related suites also green: `rollbackSafety`, `webuiObserver`, `evolveDispatch`, `solidify-helpers` (85/85).

## Risk

Low. Touches only the `--loop` daemon gate in `index.js` (no public API, no schema, no new runtime deps). The new behavior is TTL-gated and defaults to the existing sub-agent ceiling, so normal bridge cycles are unaffected; only orphaned pending runs older than 45 min are cleared. Fully overridable via env.

## Self-check

- [x] No new source file under `src/` (only `index.js` modified; not manifest-tracked).
- [x] No schema factory changes.
- [x] No `Object.assign` reference-sharing introduced.
- [x] New `EVOLVER_PENDING_STALE_MS` is read inside the loop setup (after the entry-point dotenv step), consistent with the sibling `cycleTimeoutMs` constants — not a new module-level `process.env` constant.
- [x] No new runtime dependencies.
- [x] Tests added; `node --test test/loopMode.test.js` passes locally.

## Related

Closes #556

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the `--loop` Ralph-loop gate and solidify state writes (no git rollback); TTL defaults and null-age guards limit impact on live sub-agents.
> 
> **Overview**
> Fixes **#556**: in default **bridge=true** `--loop` mode, a pending run that never solidifies could leave the Ralph-loop gate sleeping forever (the bridge-disabled auto-reject only ran when `EVOLVE_BRIDGE=false`).
> 
> The gate now uses a **staleness TTL** (`EVOLVER_PENDING_STALE_MS`, defaulting to the enforced cycle hard timeout when enabled, or **0/off** when `EVOLVER_CYCLE_TIMEOUT_ENABLED=false`). **`pendingRunAgeMs`** derives age from `last_run.created_at`/`started_at` and returns `null` when age is unknown so runs are not force-rejected. **`rejectStalePendingRun`** writes a distinct state-only rejection reason and re-checks pending status on a fresh read (TOCTOU) so a successful solidify is not overwritten.
> 
> When pending and age ≥ TTL, the daemon clears the stale run and continues; otherwise behavior is unchanged (sleep/wait). Tests cover age math, stale reject, TOCTOU, bridge-mode integration, and TTL-off when cycle timeout is disabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47ba2af8014c94ad139214dd1f42eb7cfdbe303a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->