### PR TITLE
docs(readme): add ClawHub download history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,3 +582,7 @@ Clone it into any directory you like. If you use [OpenClaw](https://openclaw.com
 [MIT](https://opensource.org/licenses/MIT)
 
 > Core evolution engine modules are distributed in obfuscated form to protect intellectual property. Source: [EvoMap/evolver](https://github.com/EvoMap/evolver).
+
+## Download History
+
+[![Download History](https://skill-history.com/chart/autogame-17/evolver.svg)](https://skill-history.com/autogame-17/evolver)


### PR DESCRIPTION
Hey! 👋

I'm Gavin — I built [skill-history.com](https://skill-history.com), a free tool that tracks ClawHub skill download history over time (think [star-history.com](https://star-history.com) but for agent skills).

I noticed your skill **Evolver** has been getting solid traction — **73012 downloads** so far — so I set up a chart page for it:

👉 **https://skill-history.com/autogame-17/evolver**

This PR adds a small download history section to the bottom of your README with a live-updating chart that refreshes daily. Here's what it looks like:

![Preview](https://skill-history.com/chart/autogame-17/evolver.svg)

No setup, no tokens, no CI changes — just an SVG embed that auto-updates.

If you'd prefer a compact badge instead of the full chart, you can swap it for this:

![Downloads](https://skill-history.com/badge/autogame-17/evolver.svg)

`![Downloads](https://skill-history.com/badge/autogame-17/evolver.svg)`

The whole thing is open source: **[github.com/pineapple-farm/skill-history](https://github.com/pineapple-farm/skill-history)**

It's a brand new project and I'm shaping it based on what skill authors actually want. If you have any feedback, feature requests, or ideas:

- [Open an issue](https://github.com/pineapple-farm/skill-history/issues/new)
- Submit a PR
- Or just drop a comment here

Totally understand if this isn't your thing — feel free to close. But if it's useful, I'm excited to see it on your README!

If you find this project useful, a ⭐ on the [repo](https://github.com/pineapple-farm/skill-history) would mean a lot — it helps other skill authors discover it.

Cheers,
Gavin
[Pineapple AI](https://pineappleai.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change; external SVG embed is comparable to the existing star-history chart.
> 
> **Overview**
> Adds a **Download History** section at the end of `README.md`, after the license block, with a linked embed to [skill-history.com](https://skill-history.com) for ClawHub download trends (`autogame-17/evolver`).
> 
> The change mirrors the existing **Star History** pattern: a heading plus an image badge that points at an external chart page. No application code, config, or CI updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e1a174a3ffb8c47345de3dad3a8e86ce61d2cf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->