### PR TITLE
docs(readme): track npm + GitHub release downloads in Download History

### DIFF
--- a/README.md
+++ b/README.md
@@ -585,4 +585,10 @@ Clone it into any directory you like. If you use [OpenClaw](https://openclaw.com
 
 ## Download History
 
-[![Download History](https://skill-history.com/chart/autogame-17/evolver.svg)](https://skill-history.com/autogame-17/evolver)
+Evolver ships through three channels — the [npm package](https://www.npmjs.com/package/@evomap/evolver), prebuilt binaries on [GitHub Releases](https://github.com/EvoMap/evolver/releases), and the [ClawHub](https://skill-history.com/autogame-17/evolver) skill registry:
+
+[![npm](https://img.shields.io/npm/dm/@evomap/evolver?logo=npm&label=npm)](https://www.npmjs.com/package/@evomap/evolver)
+[![npm total](https://img.shields.io/npm/d18m/@evomap/evolver?logo=npm&label=npm%20total)](https://npm-stat.com/charts.html?package=@evomap/evolver)
+[![GitHub releases](https://img.shields.io/github/downloads/EvoMap/evolver/total?logo=github&label=GitHub%20releases)](https://github.com/EvoMap/evolver/releases)
+
+[![ClawHub download history](https://skill-history.com/chart/autogame-17/evolver.svg)](https://skill-history.com/autogame-17/evolver)


### PR DESCRIPTION
## What

Extend the **Download History** section so it covers all three of Evolver's distribution channels instead of only ClawHub:

- **npm** `@evomap/evolver` — live monthly + 18-month download badges (npm only retains ~18 months of stats), linking to the npm-stat history chart. Currently ~8.9k/month, 26k total.
- **GitHub Releases** — total downloads across all release binary assets (darwin/linux/windows + checksums). Currently 869.
- **ClawHub** — the existing skill-history.com history chart, unchanged.

## Why

The download history shouldn't show ClawHub alone — npm and GitHub releases are the other two channels users actually install through.

## Notes

- Badges are shields.io endpoints (camo-proxied by GitHub, live-updating). All three URLs were verified to return valid SVG with real numbers before commit.
- Only ClawHub has a free embeddable history-line chart today; npm/GitHub use live badges + links to their history pages. A unified custom history chart for all three could be a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only badge and copy updates with no runtime, security, or dependency impact.
> 
> **Overview**
> The **Download History** section now documents all three install paths—npm, GitHub Releases, and ClawHub—with a short intro and live shields.io badges for npm monthly/18-month downloads and total GitHub release asset downloads, each linking to the relevant package, releases, or npm-stat chart.
> 
> The existing ClawHub skill-history chart is unchanged in role; it sits below the new badges with clearer labeling so readers see npm and GitHub metrics alongside ClawHub instead of only the registry chart.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68da3ee8f3b4d6ffd87193ed5399bd10091d8e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->