### PR TITLE
docs(codex): point setup guidance at Evolver plugin tools

### DIFF
--- a/src/adapters/codex.js
+++ b/src/adapters/codex.js
@@ -94,7 +94,12 @@ This project uses evolver for self-evolution. Hooks automatically:
 2. Detect evolution signals during file edits
 3. Record outcomes at session end
 
-For substantive tasks, call \`gep_recall\` before work and \`gep_record_outcome\` after.
+When the Codex Desktop Evolver plugin is installed, use its MCP tools directly:
+- Before substantive work, call \`evolver_status\`, then \`evolver_search_assets\` with concise task signals.
+- If assets match, call \`evolver_fetch_asset\` for the promising IDs and apply the reusable guidance.
+- After the task, call \`evolver_publish_asset\` only for reusable Genes/Capsules; otherwise rely on the installed Stop hook to record the local outcome.
+
+If your environment exposes legacy \`gep_recall\` / \`gep_record_outcome\` aliases, those aliases are equivalent workflow steps, but Codex Desktop plugin installs expose the \`evolver_*\` tool names by default.
 Signals: log_error, perf_bottleneck, user_feature_request, capability_gap, deployment_issue, test_failure.`;
 }
 

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -803,6 +803,11 @@ describe('codex adapter', () => {
       const toml = fs.readFileSync(path.join(tmp, '.codex', 'config.toml'), 'utf8');
       assert.ok(toml.includes('codex_hooks = true'));
       assert.ok(fs.existsSync(path.join(tmp, 'AGENTS.md')));
+      const agentsMd = fs.readFileSync(path.join(tmp, 'AGENTS.md'), 'utf8');
+      assert.ok(agentsMd.includes('evolver_status'));
+      assert.ok(agentsMd.includes('evolver_search_assets'));
+      assert.ok(agentsMd.includes('evolver_publish_asset'));
+      assert.ok(!agentsMd.includes('For substantive tasks, call `gep_recall` before work'));
     } finally { cleanup(tmp); }
   });
 


### PR DESCRIPTION
## Summary
- Update the Codex `setup-hooks` AGENTS.md section to reference the actual Codex Desktop Evolver MCP tool names: `evolver_status`, `evolver_search_assets`, `evolver_fetch_asset`, and `evolver_publish_asset`.
- Clarify that installed hooks already inject memory and record local outcomes automatically, while `gep_recall` / `gep_record_outcome` are legacy aliases when a host exposes them.
- Add adapter coverage so future installs do not regress to the non-default `gep_*` instruction as the primary Codex path.

## Test plan
- `node --check src/adapters/codex.js`
- `node --test test/adapters.test.js`
- `env NVM_DIR=/tmp/evolver-empty-nvm FNM_DIR=/tmp/evolver-empty-fnm ASDF_DATA_DIR=/tmp/evolver-empty-asdf node --test test/runtimePaths.test.js`
- `npm test` after `npm ci`: local run passed 2360/2361 tests; the one failure was `runtimePaths.test.js` resolving this machine's globally installed `@evomap/evolver` before the test-planted package. The isolated `runtimePaths` command above removes that local global install from the search path and passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change to generated `AGENTS.md` text plus test assertions; no runtime hook or MCP behavior changes.
> 
> **Overview**
> Updates the **Evolution Memory** block that Codex `setup-hooks` injects into `AGENTS.md` so agents are steered toward the **Codex Desktop Evolver plugin** MCP tools (`evolver_status`, `evolver_search_assets`, `evolver_fetch_asset`, `evolver_publish_asset`) instead of treating `gep_recall` / `gep_record_outcome` as the default workflow.
> 
> The new text spells out a before/during/after flow (status → search → fetch → publish only for reusable assets) and notes that installed hooks already inject memory and record local outcomes on Stop, with `gep_*` names documented only as optional legacy aliases.
> 
> Adapter tests now assert fresh installs include the `evolver_*` guidance and no longer promote the old “call `gep_recall` before work” line as the primary path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab7f4836b5ae37b47688ddf087e534ac4693836. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->