### PR TITLE
fix(claude-code): resolve evolver hooks from project OR home scope

### DIFF
--- a/src/adapters/claudeCode.js
+++ b/src/adapters/claudeCode.js
@@ -5,8 +5,23 @@ const { mergeJsonFile, copyHookScripts, appendSectionToFile, removeHookScripts, 
 const HOOK_SCRIPTS_DIR_NAME = 'hooks';
 const EVOLVER_MARKER = '<!-- evolver-evolution-memory -->';
 
+// Resolve an evolver hook script from the PROJECT's .claude/hooks first, then
+// fall back to the user-home install. The evolver can be installed at the
+// home/global scope (one shared install), but Claude Code resolves a bare
+// `.claude/hooks/...` command path against each *project* dir — so a bare
+// relative command silently fails in every project except the install root.
+// This emits a project-or-home fallback, cross-platform, so the hook fires no
+// matter where the scripts were copied.
+function buildHookCommand(scriptName) {
+  if (process.platform === 'win32') {
+    const proj = `%CLAUDE_PROJECT_DIR%\\.claude\\hooks\\${scriptName}`;
+    const home = `%USERPROFILE%\\.claude\\hooks\\${scriptName}`;
+    return `cmd /c "IF EXIST "${proj}" (node "${proj}") ELSE (node "${home}")"`;
+  }
+  return `sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/${scriptName}"; [ -f "$f" ] || f="$HOME/.claude/hooks/${scriptName}"; node "$f"'`;
+}
+
 function buildClaudeHooks(evolverRoot) {
-  const scriptsBase = '.claude/hooks';
   return {
     hooks: {
       SessionStart: [
@@ -14,7 +29,7 @@ function buildClaudeHooks(evolverRoot) {
           hooks: [
             {
               type: 'command',
-              command: `node ${scriptsBase}/evolver-session-start.js`,
+              command: buildHookCommand('evolver-session-start.js'),
               timeout: 3,
             },
           ],
@@ -32,7 +47,7 @@ function buildClaudeHooks(evolverRoot) {
               // ABOVE that watchdog, so the host never kills the script
               // mid-write. A stuck/slow recall can never block or erase the
               // user's prompt.
-              command: `node ${scriptsBase}/evolver-task-recall.js`,
+              command: buildHookCommand('evolver-task-recall.js'),
               timeout: 5,
             },
           ],
@@ -44,7 +59,7 @@ function buildClaudeHooks(evolverRoot) {
           hooks: [
             {
               type: 'command',
-              command: `node ${scriptsBase}/evolver-signal-detect.js`,
+              command: buildHookCommand('evolver-signal-detect.js'),
               timeout: 2,
             },
           ],
@@ -55,7 +70,7 @@ function buildClaudeHooks(evolverRoot) {
           hooks: [
             {
               type: 'command',
-              command: `node ${scriptsBase}/evolver-session-end.js`,
+              command: buildHookCommand('evolver-session-end.js'),
               timeout: 8,
             },
           ],

--- a/test/adapters.test.js
+++ b/test/adapters.test.js
@@ -795,6 +795,29 @@ describe('claudeCode adapter', () => {
     }
     assert.equal(hooks.hooks.PostToolUse[0].matcher, 'Write');
   });
+
+  it('buildClaudeHooks commands resolve from project OR home scope', () => {
+    // Regression: a bare `node .claude/hooks/...` command is resolved by
+    // Claude Code against each project dir, so a home/global-scoped install
+    // silently fails everywhere except the install root. Every emitted command
+    // must reference both the project scope and a home-scope fallback, and stay
+    // recognizable to the uninstall/merge matcher.
+    const hooks = claudeAdapter.buildClaudeHooks('/evolver');
+    const commands = [];
+    for (const event of Object.keys(hooks.hooks)) {
+      for (const matcher of hooks.hooks[event]) {
+        for (const cmd of matcher.hooks) commands.push(cmd.command);
+      }
+    }
+    assert.ok(commands.length >= 4, 'expected at least 4 hook commands');
+    const homeMarker = process.platform === 'win32' ? 'USERPROFILE' : 'HOME';
+    for (const cmd of commands) {
+      assert.ok(cmd.includes('CLAUDE_PROJECT_DIR'), `command must try project scope: ${cmd}`);
+      assert.ok(cmd.includes(homeMarker), `command must fall back to home scope: ${cmd}`);
+      assert.ok(/evolver-[a-z-]+\.js/.test(cmd), `command must invoke an evolver hook script: ${cmd}`);
+      assert.ok(hookAdapter.isEvolverHookCommand(cmd), `command must stay recognizable to uninstall: ${cmd}`);
+    }
+  });
 });
 
 // -- Codex adapter --


### PR DESCRIPTION
## Problem

`buildClaudeHooks()` in `src/adapters/claudeCode.js` emits bare relative commands:

```js
command: `node .claude/hooks/evolver-session-start.js`
```

Claude Code resolves a hook command's relative path against the **project** directory (`%CLAUDE_PROJECT_DIR%`), not the evolver install root. When evolver is installed once at the **home/global scope** — hooks in `~/.claude/hooks`, `_evolver_managed` settings in `~/.claude/settings.json` — every project *except* the install root resolves `.claude/hooks/evolver-*.js` to a non-existent path.

The hooks then fail silently: their 2–8 ms `timeout` values mean the host swallows the error. Session-start memory injection, signal detection, task recall, and outcome recording **never run** in those projects, with no visible error. (Observed in the wild on a Windows global install: hooks present in `~/.claude/hooks`, but a project on another drive never fired any of them.)

## Fix

Emit a **project-or-home fallback** command, cross-platform:

- **win32:** `cmd /c "IF EXIST "%CLAUDE_PROJECT_DIR%\.claude\hooks\X" (node "%CLAUDE_PROJECT_DIR%\.claude\hooks\X") ELSE (node "%USERPROFILE%\.claude\hooks\X")"`
- **posix:** `sh -c 'f="$CLAUDE_PROJECT_DIR/.claude/hooks/X"; [ -f "$f" ] || f="$HOME/.claude/hooks/X"; node "$f"'`

Tries the project-local copy first (so per-project installs and the `copyHookScripts` path keep working), then falls back to the home install — so the hook fires no matter which scope it was installed at.

The emitted commands still contain the `evolver-*.js` script names, so `isEvolverHookCommand()` keeps matching them and `uninstall()` / merge dedup are unaffected.

## Test

Adds `buildClaudeHooks commands resolve from project OR home scope` to `test/adapters.test.js`, asserting every emitted command (1) references the project scope, (2) falls back to the home scope, (3) invokes an `evolver-*.js` script, and (4) stays recognizable to the uninstall matcher.

Full suite green locally (`node --test`): **56 passed, 0 failed**.

## Notes

- No behavior change for an already-correct per-project install — the `IF EXIST` / `[ -f ]` branch picks the project copy first.
- Cross-platform; `process.platform` selects the shell form.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Hook install path resolution only; uninstall matching unchanged and per-project installs still prefer local scripts.
> 
> **Overview**
> Fixes **silent hook failures** when evolver is installed at home/global scope: Claude Code used to resolve bare `node .claude/hooks/evolver-*.js` against each **project** directory, so session memory, signal detection, task recall, and session-end recording never ran outside the install root.
> 
> `buildClaudeHooks()` now emits **project-then-home** shell commands via new `buildHookCommand()` (Windows `cmd` + `IF EXIST` / `%USERPROFILE%`, POSIX `sh` with `$CLAUDE_PROJECT_DIR` then `$HOME`). Per-project installs are unchanged because the project copy is tried first.
> 
> A regression test asserts every emitted command references both scopes, still invokes `evolver-*.js`, and remains matched by `isEvolverHookCommand()` for uninstall/merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1bb856b9918995a72c34006bb7a665654981e041. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->