### PR TITLE
Add MiniMax OpenAI-compatible endpoint

### DIFF
--- a/src/proxy/index.js
+++ b/src/proxy/index.js
@@ -29,6 +29,9 @@ const TRACE_BACKFILL_RUNTIME_DRAIN_MAX_MS = 50;
 function _defaultDataDir() { return getEvomapPath('mailbox'); }
 
 const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1';
+const OPENAI_COMPATIBLE_BASE_URLS = Object.freeze({
+  minimax: 'https://api.minimax.io/v1',
+});
 const DEFAULT_GEMINI_BASE_URL = 'https://generativelanguage.googleapis.com';
 const DEFAULT_OLLAMA_BASE_URL = 'http://127.0.0.1:11434';
 
@@ -47,16 +50,19 @@ function resolveOpenAIBaseUrl(raw, { trustedOverride = false } = {}) {
   } catch {
     throw new Error('[proxy] EVOMAP_OPENAI_BASE_URL is not a valid URL');
   }
+
+  const canonicalValue = `${parsed.origin}${parsed.pathname}`;
+  const allowedCompatibleUrl = Object.values(OPENAI_COMPATIBLE_BASE_URLS).includes(canonicalValue);
   if (
     parsed.protocol !== 'https:'
-    || !isAllowedOpenAIHostname(parsed.hostname)
+    || (!isAllowedOpenAIHostname(parsed.hostname) && !allowedCompatibleUrl)
     || parsed.pathname !== '/v1'
     || parsed.username
     || parsed.password
     || parsed.search
     || parsed.hash
   ) {
-    throw new Error('[proxy] EVOMAP_OPENAI_BASE_URL must be an OpenAI https://*.api.openai.com/v1 endpoint');
+    throw new Error('[proxy] EVOMAP_OPENAI_BASE_URL must be an OpenAI or known OpenAI-compatible https /v1 endpoint');
   }
   return value;
 }
@@ -1392,4 +1398,5 @@ module.exports = {
   planAssetSearch,
   parseRetryAfterMs,
   resolveOpenAIBaseUrl,
+  OPENAI_COMPATIBLE_BASE_URLS,
 };

--- a/test/proxyOpenAIResponses.test.js
+++ b/test/proxyOpenAIResponses.test.js
@@ -228,7 +228,7 @@ describe('EvoMapProxy._proxyOpenAIResponses', () => {
     const unsafeProxy = new EvoMapProxy({ logger: { log: () => {}, warn: () => {}, error: () => {} } });
     await assert.rejects(
       () => unsafeProxy._proxyOpenAIResponses('/responses', { model: 'gpt-5.5', input: 'hi' }, { inboundHeaders: {} }),
-      /EVOMAP_OPENAI_BASE_URL must be an OpenAI https/,
+      /EVOMAP_OPENAI_BASE_URL must be an OpenAI or known OpenAI-compatible https \/v1 endpoint/,
     );
   });
 
@@ -245,12 +245,16 @@ describe('EvoMapProxy._proxyOpenAIResponses', () => {
       const unsafeProxy = new EvoMapProxy({ logger: { log: () => {}, warn: () => {}, error: () => {} } });
       await assert.rejects(
         () => unsafeProxy._proxyOpenAIResponses('/responses', { model: 'gpt-5.5', input: raw }, { inboundHeaders: {} }),
-        /EVOMAP_OPENAI_BASE_URL must be an OpenAI https/,
+        /EVOMAP_OPENAI_BASE_URL must be an OpenAI or known OpenAI-compatible https \/v1 endpoint/,
       );
     }
   });
 
   it('accepts OpenAI regional HTTPS base URLs from environment', () => {
     assert.equal(resolveOpenAIBaseUrl('https://us.api.openai.com/v1/'), 'https://us.api.openai.com/v1');
+  });
+
+  it('accepts the MiniMax OpenAI-compatible base URL from environment', () => {
+    assert.equal(resolveOpenAIBaseUrl('https://api.minimax.io/v1/'), 'https://api.minimax.io/v1');
   });
 });

--- a/test/v1Responses.test.js
+++ b/test/v1Responses.test.js
@@ -293,10 +293,10 @@ describe('POST /v1/responses — OpenAI upstream diagnostics', () => {
     assert.equal(res.status, 502);
     const body = JSON.parse(res.body);
     assert.match(body.error, /^openai upstream request failed:/);
-    assert.match(body.error, /EVOMAP_OPENAI_BASE_URL must be an OpenAI https/);
+    assert.match(body.error, /EVOMAP_OPENAI_BASE_URL must be an OpenAI or known OpenAI-compatible https \/v1 endpoint/);
 
     const logText = logs.map((entry) => entry.map(String).join(' ')).join('\n');
-    assert.match(logText, /EVOMAP_OPENAI_BASE_URL must be an OpenAI https/);
+    assert.match(logText, /EVOMAP_OPENAI_BASE_URL must be an OpenAI or known OpenAI-compatible https \/v1 endpoint/);
     assert.doesNotMatch(logText, new RegExp(token));
     assert.doesNotMatch(logText, new RegExp(inboundKey));
     assert.doesNotMatch(logText, new RegExp(openAIKey));


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

## Summary
- Add MiniMax to the proxy's known OpenAI-compatible base URL allowlist.
- Keep existing OpenAI endpoint safety checks for protocol, path, credentials, query, and fragment.
- Update diagnostics tests and cover the MiniMax base URL.

## Test plan
- `node --test test/proxyOpenAIResponses.test.js test/v1Responses.test.js`
