### PR TITLE
fix(opencode): use PluginModule export for opencode 1.18.x compatibility

### DIFF
--- a/src/adapters/opencode.js
+++ b/src/adapters/opencode.js
@@ -72,8 +72,7 @@ const Evolver = async () => ({
   },
 });
 
-module.exports = { Evolver };
-module.exports.default = Evolver;
+module.exports = { id: "evolver", server: Evolver };
 `;
 }
 
@@ -220,7 +219,7 @@ function verify({ configRoot }) {
       // failure here is a guaranteed failure under opencode too.
       delete require.cache[require.resolve(pluginPath)];
       const mod = require(pluginPath);
-      const fn = mod && (mod.Evolver || mod.default);
+      const fn = mod && (mod.server || mod.Evolver || mod.default);
       pluginLoadable = typeof fn === 'function';
       if (!pluginLoadable) pluginLoadError = 'no Evolver/default function export';
     } catch (err) {


### PR DESCRIPTION
## Problem

`evolver setup-hooks --platform=opencode` generates a plugin file whose export shape is rejected by opencode 1.18.x at load time:

```
level=ERROR message="failed to load plugin"
path=file:///.../.opencode/plugins/evolver.js
error="Plugin export is not a function"
```

The generated file currently ends with:

```js
module.exports = { Evolver };
module.exports.default = Evolver;
```

Under Bun (opencode's runtime), the whole `module.exports` object is treated as the default export, so opencode receives `{ Evolver }` rather than a function and bails out. The plugin is silently skipped — `evolver setup-hooks --platform=opencode --verify` still passes because it uses Node's `require()` which sees `Evolver` as a named export. This means the two disagree, and users only find out when they check `opencode debug config`.

## Reproduction

```bash
npm install -g @evomap/evolver
evolver setup-hooks --platform=opencode
opencode --print-logs --log-level INFO debug config 2>&1 | grep evolver
```

Tested on:
- opencode 1.18.4 (scoop install)
- `@evomap/evolver` 1.92.1 (npm)
- Node v26.1.0, Windows Server 2022

## Fix

opencode 1.18.x accepts either a bare function as the default export or a PluginModule object of shape `{ id, server }`. This PR switches to the PluginModule form, which is what the official opencode plugin docs use ([opencode.ai/docs/plugins](https://opencode.ai/docs/plugins/)).

```diff
- module.exports = { Evolver };
- module.exports.default = Evolver;
+ module.exports = { id: "evolver", server: Evolver };
```

The second change updates `verify()` to recognise the new shape. Without it, the existing `mod.Evolver || mod.default` lookup would return `undefined` on the patched export and `--verify` would falsely report `[FAIL] plugin_loadable`:

```diff
- const fn = mod && (mod.Evolver || mod.default);
+ const fn = mod && (mod.server || mod.Evolver || mod.default);
```

## Verification

Applied the patch locally and ran the full flow end-to-end:

- `opencode --print-logs --log-level INFO debug config` → **0 ERROR / WARN entries** (previously `failed to load plugin`)
- `evolver setup-hooks --platform=opencode --verify` → all 5 checks `[OK]`
- Other plugins (`superpowers`, `context-mode`, `opencode-vision`, `opencode-goal-plugin`) unaffected

## Related

- #531 — same export format worked on earlier opencode versions (the `loading plugin` INFO log was present). Looks like opencode 1.18.x tightened plugin validation, which surfaces this latent issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small export-shape change in the opencode adapter only; no auth, data, or core runtime logic changes.
> 
> **Overview**
> Fixes opencode **1.18.x** rejecting the generated evolver plugin with **"Plugin export is not a function"** under Bun, while `evolver setup-hooks --platform=opencode --verify` could still pass under Node.
> 
> The generated `evolver.js` now uses the documented **PluginModule** export (`{ id: "evolver", server: Evolver }`) instead of `{ Evolver }` plus a `default` assignment. **`verify()`** resolves the plugin factory via `mod.server` first (then `Evolver` / `default`) so `--verify` matches what opencode loads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b9b7737809fa1ac4cb3b3d78919ac551cae57b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->