### PR TITLE
fix: fail closed on unavailable llm review

### DIFF
--- a/src/gep/llmReview.js
+++ b/src/gep/llmReview.js
@@ -114,11 +114,11 @@ function classifyExecutionError(error) {
 
 function defaultExecute({ prompt, timeoutMs }) {
   const repoRoot = getRepoRoot();
-  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-review-'));
-  const tmpFile = path.join(tmpDir, 'prompt.txt');
-  fs.writeFileSync(tmpFile, prompt, 'utf8');
-
+  let tmpDir;
   try {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-review-'));
+    const tmpFile = path.join(tmpDir, 'prompt.txt');
+    fs.writeFileSync(tmpFile, prompt, 'utf8');
     const reviewScript = `
       const fs = require('fs');
       const prompt = fs.readFileSync(process.argv[1], 'utf8');
@@ -132,7 +132,9 @@ function defaultExecute({ prompt, timeoutMs }) {
       windowsHide: true,
     });
   } finally {
-    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
+    if (tmpDir) {
+      try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
+    }
   }
 }
 

--- a/src/gep/llmReview.js
+++ b/src/gep/llmReview.js
@@ -8,6 +8,7 @@ const { getRepoRoot } = require('./paths');
 
 const REVIEW_ENABLED_KEY = 'EVOLVER_LLM_REVIEW';
 const REVIEW_TIMEOUT_MS = 30000;
+const REVIEW_MAX_ATTEMPTS = 2;
 
 function isLlmReviewEnabled() {
   return String(process.env[REVIEW_ENABLED_KEY] || '').toLowerCase() === 'true';
@@ -48,45 +49,128 @@ Respond with a JSON object:
 }`;
 }
 
-function runLlmReview({ diff, gene, signals, mutation }) {
-  if (!isLlmReviewEnabled()) return null;
+function failureResult(reason, summary, trace) {
+  return {
+    approved: false,
+    confidence: 0,
+    concerns: [summary],
+    summary,
+    status: 'unavailable',
+    reason,
+    retryable: true,
+    attempts: trace.length,
+    trace,
+  };
+}
 
-  const prompt = buildReviewPrompt({ diff, gene, signals, mutation });
+function parseReviewResponse(output) {
+  const text = typeof output === 'string' ? output.trim() : '';
+  if (!text) {
+    return { ok: false, reason: 'empty_output', summary: 'review returned empty output' };
+  }
+
+  let parsed;
+  try {
+    parsed = JSON.parse(text);
+  } catch (_) {
+    const partial = /^[{[]/.test(text) && !/[}\]]\s*$/.test(text);
+    return {
+      ok: false,
+      reason: partial ? 'partial_response' : 'malformed_output',
+      summary: partial ? 'review returned a partial response' : 'review returned malformed output',
+    };
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed) ||
+      typeof parsed.approved !== 'boolean' ||
+      !Number.isFinite(parsed.confidence) || parsed.confidence < 0 || parsed.confidence > 1 ||
+      !Array.isArray(parsed.concerns) || !parsed.concerns.every(item => typeof item === 'string') ||
+      typeof parsed.summary !== 'string' || !parsed.summary.trim()) {
+    return { ok: false, reason: 'partial_response', summary: 'review response was incomplete' };
+  }
+
+  return {
+    ok: true,
+    value: {
+      approved: parsed.approved,
+      confidence: parsed.confidence,
+      concerns: parsed.concerns,
+      summary: parsed.summary.trim(),
+      status: parsed.approved ? 'approved' : 'rejected',
+      reason: parsed.approved ? 'review_approved' : 'review_rejected',
+      retryable: false,
+    },
+  };
+}
+
+function classifyExecutionError(error) {
+  const message = error && error.message ? String(error.message) : String(error);
+  const timedOut = Boolean(error && (error.code === 'ETIMEDOUT' || error.signal === 'SIGTERM')) || /timed?\s*out|ETIMEDOUT/i.test(message);
+  return {
+    reason: timedOut ? 'timeout' : 'runner_error',
+    summary: timedOut ? 'review timed out' : 'review execution failed',
+  };
+}
+
+function defaultExecute({ prompt, timeoutMs }) {
+  const repoRoot = getRepoRoot();
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'evolver-review-'));
+  const tmpFile = path.join(tmpDir, 'prompt.txt');
+  fs.writeFileSync(tmpFile, prompt, 'utf8');
 
   try {
-    const repoRoot = getRepoRoot();
-
-    // Write prompt to a temp file to avoid shell quoting issues entirely.
-    const tmpFile = path.join(os.tmpdir(), 'evolver_review_prompt_' + process.pid + '.txt');
-    fs.writeFileSync(tmpFile, prompt, 'utf8');
-
-    try {
-      // Use execFileSync to bypass shell interpretation (no quoting issues).
-      const reviewScript = `
-        const fs = require('fs');
-        const prompt = fs.readFileSync(process.argv[1], 'utf8');
-        console.log(JSON.stringify({ approved: true, confidence: 0.7, concerns: [], summary: 'auto-approved (no external LLM configured)' }));
-      `;
-      const result = execFileSync(process.execPath, ['-e', reviewScript, tmpFile], {
-        cwd: repoRoot,
-        encoding: 'utf8',
-        timeout: REVIEW_TIMEOUT_MS,
-        stdio: ['ignore', 'pipe', 'pipe'],
-        windowsHide: true,
-      });
-
-      try {
-        return JSON.parse(result.trim());
-      } catch (_) {
-        return { approved: true, confidence: 0.5, concerns: ['failed to parse review response'], summary: 'review parse error' };
-      }
-    } finally {
-      try { fs.unlinkSync(tmpFile); } catch (_) {}
-    }
-  } catch (e) {
-    console.log('[LLMReview] Execution failed (non-fatal): ' + (e && e.message ? e.message : e));
-    return { approved: true, confidence: 0.5, concerns: ['review execution failed'], summary: 'review timeout or error' };
+    const reviewScript = `
+      const fs = require('fs');
+      const prompt = fs.readFileSync(process.argv[1], 'utf8');
+      console.log(JSON.stringify({ approved: true, confidence: 0.7, concerns: [], summary: 'auto-approved (no external LLM configured)' }));
+    `;
+    return execFileSync(process.execPath, ['-e', reviewScript, tmpFile], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+  } finally {
+    try { fs.rmSync(tmpDir, { recursive: true, force: true }); } catch (_) {}
   }
 }
 
-module.exports = { isLlmReviewEnabled, runLlmReview, buildReviewPrompt };
+function runLlmReview({ diff, gene, signals, mutation }, options) {
+  if (!isLlmReviewEnabled()) return null;
+
+  const opts = options || {};
+  const execute = typeof opts.execute === 'function' ? opts.execute : defaultExecute;
+  const timeoutMs = Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0 ? opts.timeoutMs : REVIEW_TIMEOUT_MS;
+  const maxAttempts = Number.isInteger(opts.maxAttempts) && opts.maxAttempts > 0 ? opts.maxAttempts : REVIEW_MAX_ATTEMPTS;
+  const prompt = buildReviewPrompt({ diff, gene, signals, mutation });
+  const trace = [];
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    let failure;
+    try {
+      const parsed = parseReviewResponse(execute({ prompt, timeoutMs, attempt }));
+      if (parsed.ok) {
+        trace.push({ attempt, status: parsed.value.status, reason: parsed.value.reason });
+        return Object.assign({}, parsed.value, { attempts: attempt, trace });
+      }
+      failure = parsed;
+    } catch (error) {
+      failure = classifyExecutionError(error);
+    }
+
+    trace.push({ attempt, status: 'unavailable', reason: failure.reason });
+    if (attempt === maxAttempts) {
+      console.log('[LLMReview] Unavailable: ' + failure.reason + ' after ' + attempt + ' attempt(s)');
+      return failureResult(failure.reason, failure.summary, trace);
+    }
+  }
+}
+
+module.exports = {
+  isLlmReviewEnabled,
+  runLlmReview,
+  buildReviewPrompt,
+  parseReviewResponse,
+  classifyExecutionError,
+};

--- a/test/llmReview.test.js
+++ b/test/llmReview.test.js
@@ -153,6 +153,25 @@ describe('llmReview fail-closed boundary', function () {
     assert.deepEqual(after.filter(name => !before.has(name)), []);
   });
 
+  it('does not leak a temp directory when prompt write fails', function () {
+    const before = new Set(fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('evolver-review-')));
+    const originalWrite = fs.writeFileSync;
+    fs.writeFileSync = function (file) {
+      if (String(file).includes('evolver-review-') && String(file).endsWith('prompt.txt')) {
+        throw new Error('ENOSPC: no space left on device');
+      }
+      return originalWrite.apply(this, arguments);
+    };
+    try {
+      const result = runLlmReview(input, { maxAttempts: 1, timeoutMs: 5000 });
+      assertUnavailable(result, 'runner_error', 1);
+    } finally {
+      fs.writeFileSync = originalWrite;
+    }
+    const after = fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('evolver-review-'));
+    assert.deepEqual(after.filter(name => !before.has(name)), []);
+  });
+
   it('returns null when review is disabled', function () {
     process.env.EVOLVER_LLM_REVIEW = 'false';
     assert.equal(runLlmReview(input, { execute: () => { throw new Error('must not run'); } }), null);

--- a/test/llmReview.test.js
+++ b/test/llmReview.test.js
@@ -1,0 +1,168 @@
+'use strict';
+
+const { describe, it, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+
+const { runLlmReview, parseReviewResponse } = require('../src/gep/llmReview');
+
+const input = {
+  diff: 'diff --git a/example.js b/example.js\n+const safe = true;',
+  gene: { id: 'gene_llm_review_test', category: 'repair' },
+  signals: ['review-boundary'],
+  mutation: { rationale: 'exercise the review boundary' },
+};
+
+let previousEnabled;
+beforeEach(function () {
+  previousEnabled = process.env.EVOLVER_LLM_REVIEW;
+  process.env.EVOLVER_LLM_REVIEW = 'true';
+});
+afterEach(function () {
+  if (previousEnabled === undefined) delete process.env.EVOLVER_LLM_REVIEW;
+  else process.env.EVOLVER_LLM_REVIEW = previousEnabled;
+});
+
+function assertUnavailable(result, reason, attempts) {
+  assert.equal(result.approved, false);
+  assert.equal(result.status, 'unavailable');
+  assert.equal(result.reason, reason);
+  assert.equal(result.retryable, true);
+  assert.equal(result.attempts, attempts);
+  assert.equal(result.trace.length, attempts);
+  assert.ok(result.trace.every(entry => entry.status === 'unavailable'));
+}
+
+describe('llmReview fail-closed boundary', function () {
+  it('does not approve malformed output after retry exhaustion', function () {
+    const result = runLlmReview(input, { execute: () => 'not-json', maxAttempts: 2 });
+    assertUnavailable(result, 'malformed_output', 2);
+  });
+
+  it('does not approve empty output after retry exhaustion', function () {
+    const result = runLlmReview(input, { execute: () => '  \n', maxAttempts: 2 });
+    assertUnavailable(result, 'empty_output', 2);
+  });
+
+  it('does not approve runner errors after retry exhaustion', function () {
+    const result = runLlmReview(input, {
+      execute: () => { const error = new Error('runner failed'); error.code = 'EIO'; throw error; },
+      maxAttempts: 2,
+    });
+    assertUnavailable(result, 'runner_error', 2);
+  });
+
+  it('does not approve timeouts after retry exhaustion', function () {
+    const result = runLlmReview(input, {
+      execute: () => { const error = new Error('spawnSync node ETIMEDOUT'); error.code = 'ETIMEDOUT'; throw error; },
+      maxAttempts: 2,
+    });
+    assertUnavailable(result, 'timeout', 2);
+  });
+
+  it('does not approve truncated or structurally partial responses', function () {
+    const truncated = runLlmReview(input, {
+      execute: () => '{"approved":true,"confidence":',
+      maxAttempts: 1,
+    });
+    assertUnavailable(truncated, 'partial_response', 1);
+
+    const incomplete = runLlmReview(input, {
+      execute: () => JSON.stringify({ approved: true, confidence: 0.8 }),
+      maxAttempts: 1,
+    });
+    assertUnavailable(incomplete, 'partial_response', 1);
+  });
+
+  it('retries a recoverable failure and preserves the valid success path', function () {
+    let calls = 0;
+    const result = runLlmReview(input, {
+      execute: () => {
+        calls += 1;
+        if (calls === 1) return '';
+        return JSON.stringify({ approved: true, confidence: 0.9, concerns: [], summary: 'verified' });
+      },
+      maxAttempts: 2,
+    });
+
+    assert.equal(result.approved, true);
+    assert.equal(result.status, 'approved');
+    assert.equal(result.reason, 'review_approved');
+    assert.equal(result.retryable, false);
+    assert.equal(result.attempts, 2);
+    assert.deepEqual(result.trace, [
+      { attempt: 1, status: 'unavailable', reason: 'empty_output' },
+      { attempt: 2, status: 'approved', reason: 'review_approved' },
+    ]);
+  });
+
+  it('preserves explicit rejection and compatibility fields', function () {
+    const result = runLlmReview(input, {
+      execute: () => JSON.stringify({
+        approved: false,
+        confidence: 0.95,
+        concerns: ['unsafe mutation'],
+        summary: 'reject unsafe mutation',
+      }),
+      maxAttempts: 1,
+    });
+
+    assert.deepEqual(
+      {
+        approved: result.approved,
+        confidence: result.confidence,
+        concerns: result.concerns,
+        summary: result.summary,
+        status: result.status,
+        reason: result.reason,
+      },
+      {
+        approved: false,
+        confidence: 0.95,
+        concerns: ['unsafe mutation'],
+        summary: 'reject unsafe mutation',
+        status: 'rejected',
+        reason: 'review_rejected',
+      }
+    );
+  });
+
+  it('is idempotent for the same input and deterministic runner output', function () {
+    const prompts = [];
+    const execute = ({ prompt }) => {
+      prompts.push(prompt);
+      return JSON.stringify({ approved: true, confidence: 0.8, concerns: [], summary: 'stable review' });
+    };
+
+    const first = runLlmReview(input, { execute, maxAttempts: 1 });
+    const second = runLlmReview(input, { execute, maxAttempts: 1 });
+
+    assert.deepEqual(second, first);
+    assert.equal(prompts.length, 2);
+    assert.equal(prompts[1], prompts[0]);
+  });
+
+  it('records a real subprocess trace and removes its temporary directory', function () {
+    const before = new Set(fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('evolver-review-')));
+    const result = runLlmReview(input, { maxAttempts: 1, timeoutMs: 5000 });
+    const after = fs.readdirSync(os.tmpdir()).filter(name => name.startsWith('evolver-review-'));
+
+    assert.equal(result.approved, true);
+    assert.deepEqual(result.trace, [{ attempt: 1, status: 'approved', reason: 'review_approved' }]);
+    assert.deepEqual(after.filter(name => !before.has(name)), []);
+  });
+
+  it('returns null when review is disabled', function () {
+    process.env.EVOLVER_LLM_REVIEW = 'false';
+    assert.equal(runLlmReview(input, { execute: () => { throw new Error('must not run'); } }), null);
+  });
+});
+
+describe('parseReviewResponse', function () {
+  it('rejects out-of-range confidence', function () {
+    const invalid = parseReviewResponse(JSON.stringify({ approved: true, confidence: 2, concerns: [], summary: 'bad' }));
+    assert.equal(invalid.ok, false);
+    assert.equal(invalid.reason, 'partial_response');
+  });
+});


### PR DESCRIPTION
## Summary

Harden the `llmReview` trust boundary so malformed, empty, partial, timed-out, or failed review execution can never approve a solidification candidate. Preserve valid approval/rejection compatibility fields while adding typed recoverable status, retry metadata, and attempt traces.

## What changed

- Added strict validation for the complete review response contract before approval.
- Classified unavailable outcomes as `malformed_output`, `empty_output`, `partial_response`, `runner_error`, or `timeout` and made each fail closed with `approved: false`.
- Added one bounded retry by default, deterministic executor injection for tests, and per-attempt trace metadata.
- Added regression coverage for malformed, empty, runner failure, timeout, partial, retry recovery, explicit rejection, idempotency, disabled mode, and a real subprocess trace with temporary-directory cleanup.

## How to test

1. `node --test test/llmReview.test.js`
2. `PATH=/opt/homebrew/opt/node@22/bin:$PATH npm test` (runs all 3,299 project tests locally; 3,259 passed and 40 unrelated black-box CLI/proxy timing tests hit their fixed local 10–20 second deadlines; `llmReview` passed inside the full run; hosted CI is the clean-environment full-suite authority)
3. `node --test test/solidify-helpers.test.js test/solidifyLearning.test.js` (68/68 pass)
4. `node --check src/gep/llmReview.js && node --check test/llmReview.test.js && git diff --check`
5. `node index.js --help`
6. `node scripts/harness-governance-check.js --body <this-pr-body> --changed <changed-files>`

Expected: focused and adjacent suites pass; `llmReview` passes in the full test run; static checks and CLI sanity exit zero; governance gate reports `PASSED`. Hosted CI must pass the complete suite before merge.

## Risk

Medium -- this intentionally changes enabled `llmReview` infrastructure failures from approval to a recoverable fail-closed rejection. The default placeholder success path, explicit model approval/rejection, disabled-mode `null`, and legacy compatibility fields remain unchanged.

## Harness/evaluator governance

Upstream governance surface: `src/gep/llmReview.js` review parsing, execution, retry, and approval invariant only.
Downstream EvoX impact: Enabled review failures now return `approved: false` with typed recoverable metadata; no bridge schema or runtime API changes outside the existing review result object.
Rollout-local scope: Applies only when `EVOLVER_LLM_REVIEW=true`; disabled mode remains unchanged.
Promotion boundary: Merge makes the fail-closed invariant the default only inside the opt-in llmReview path; no live promotion is performed by this PR.
Evaluator mismatch sets: Observation adds typed failure reasons and attempt traces; action changes only unverifiable failures from approval to rejection; repair adds bounded retry; verification covers malformed, empty, partial, runner error, timeout, success, rejection, idempotency, and real subprocess trace; evidence is the focused/full test output; belief changes from fail-open to fail-closed for unavailable reviews.
Non-regression evidence: Focused `test/llmReview.test.js` (11/11), adjacent solidify tests (68/68), full Node 22 run (3,299 executed; 3,259 passed; 40 unrelated local black-box timing failures; llmReview passed), syntax/whitespace checks, CLI sanity, before/after failure probe, and harness governance gate. Hosted CI is required before merge.
Fix-severity review: high
Owner approval: GEP llmReview/evaluator owner review required.
Security boundary: No new data, network, host, tool, or secrets access; temporary prompts remain local and are removed after each attempt. Trust is tightened because unverified output cannot authorize a candidate.
Rollback: Revert this commit to restore prior behavior; operationally disable the opt-in path with `EVOLVER_LLM_REVIEW=false` while investigating.
Live promotion: no
Autonomous evaluator self-editing: no

## Self-check

- [x] Tests added or updated to cover the new behavior; focused and adjacent suites pass locally, the full suite executed all 3,299 tests with only unrelated fixed-deadline black-box timing failures, and hosted CI is required before merge.
- [x] No new runtime dependencies added.

## Related

N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes behavior on the evolution trust boundary when LLM review is enabled: unverifiable review outcomes flip from fail-open approval to fail-closed rejection, which can block candidates that previously slipped through.
> 
> **Overview**
> **Hardens the opt-in `llmReview` gate** so infrastructure or bad output can no longer implicitly approve solidification candidates when `EVOLVER_LLM_REVIEW=true`.
> 
> Previously, parse failures, runner errors, and timeouts could still yield `approved: true` with low confidence. The flow now **validates the full JSON contract** (`approved`, bounded `confidence`, `concerns`, non-empty `summary`), **retries once by default**, and on exhaustion returns **`approved: false`** with `status: 'unavailable'`, typed `reason` (`malformed_output`, `empty_output`, `partial_response`, `runner_error`, `timeout`), `retryable: true`, and per-attempt **trace**. Valid explicit approve/reject paths keep the legacy fields plus `status`/`reason`. Execution is injectable for tests; default subprocess temp dirs use `mkdtemp` and are removed after each attempt.
> 
> Adds **`test/llmReview.test.js`** covering fail-closed cases, retry recovery, rejection, idempotency, disabled mode, and subprocess cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b094d5b7999b8a84246898a8996a53a3a3b34d75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->